### PR TITLE
Implement actions based on docker buildx action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -64,8 +64,7 @@ jobs:
       # Build "latest"
       - 
         name: Build & Push - latest
-        # --push
-        run: docker buildx build --no-cache --progress plain -t "${{ env.REPO }}/${{ env.IMAGE }}:latest" --compress --platform "linux/386,linux/amd64,linux/arm/v7,linux/arm/v6,linux/arm64" .
+        run: docker buildx build --no-cache --progress plain -t "${{ env.REPO }}/${{ env.IMAGE }}:latest" --compress --push --platform "linux/386,linux/amd64,linux/arm/v7,linux/arm/v6,linux/arm64" .
 
       # Get version from "latest"
       -
@@ -77,9 +76,8 @@ jobs:
       # Build version specific
       - 
         name: Build & Push - version specific
-        # --push
         run: |
-          docker buildx build --progress plain -t "${{ env.REPO }}/${{ env.IMAGE }}:${{ env.VERSION_TAG }}" --compress --platform "linux/386,linux/amd64,linux/arm/v7,linux/arm/v6,linux/arm64" .
+          docker buildx build --progress plain -t "${{ env.REPO }}/${{ env.IMAGE }}:${{ env.VERSION_TAG }}" --compress --push --platform "linux/386,linux/amd64,linux/arm/v7,linux/arm/v6,linux/arm64" .
 
       # Patch dockerfile to remove healthcheck
       -
@@ -89,12 +87,10 @@ jobs:
       # Build "latest_nohealthcheck"
       - 
         name: Build & Push - latest nohealthcheck
-        # --push
-        run: docker buildx build -f Dockerfile.nohealthcheck --no-cache --progress plain -t "${{ env.REPO }}/${{ env.IMAGE }}:latest_nohealthcheck" --compress --platform "linux/386,linux/amd64,linux/arm/v7,linux/arm/v6,linux/arm64" .
+        run: docker buildx build -f Dockerfile.nohealthcheck --no-cache --progress plain -t "${{ env.REPO }}/${{ env.IMAGE }}:latest_nohealthcheck" --compress --push --platform "linux/386,linux/amd64,linux/arm/v7,linux/arm/v6,linux/arm64" .
 
       # Build version specific _nohealthcheck
       - 
         name: Build & Push - version specific nohealthcheck
-        # --push
         run: |
-          docker buildx build -f Dockerfile.nohealthcheck --progress plain -t "${{ env.REPO }}/${{ env.IMAGE }}:${{ env.VERSION_TAG }}_nohealthcheck" --compress --platform "linux/386,linux/amd64,linux/arm/v7,linux/arm/v6,linux/arm64" .
+          docker buildx build -f Dockerfile.nohealthcheck --progress plain -t "${{ env.REPO }}/${{ env.IMAGE }}:${{ env.VERSION_TAG }}_nohealthcheck" --compress --push --platform "linux/386,linux/amd64,linux/arm/v7,linux/arm/v6,linux/arm64" .

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,10 +2,10 @@ name: Deploy to Docker Hub
 
 on:
 
-  # Build and deploy the image on pushes to master branch
+  # Build and deploy the image on pushes to main branch
   push:
-    #branches: 
-    #  - master
+    branches: 
+      - main
 
   # Build and deploy the image nightly (to ensure we pick up any security updates)
   schedule:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,100 @@
+name: Deploy to Docker Hub
+
+on:
+
+  # Build and deploy the image on pushes to master branch
+  push:
+    #branches: 
+    #  - master
+
+  # Build and deploy the image nightly (to ensure we pick up any security updates)
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  deploy_dockerhub:
+    name: Deploy to DockerHub
+    runs-on: ubuntu-latest
+
+    # Set job-wide environment variables
+    #  - REPO: repo name on dockerhub
+    #  - IMAGE: image name on dockerhub
+    env:
+      REPO: fredclausen
+      IMAGE: acarshub
+    steps:
+
+      # Check out our code
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+
+      # Hit an issue where arm builds would fail with cURL errors regarding intermediary certificates when downloading from github (ie: deploy-s6-overlay).
+      # After many hours of troubleshooting, the workaround is to pre-load the image's rootfs with the CA certificates from the runner.
+      # This problem may go away in future.
+      - 
+        name: Copy CA Certificates from GitHub Runner to Image rootfs
+        run: |
+          ls -la /etc/ssl/certs/
+          mkdir -p ./rootfs/etc/ssl/certs
+          mkdir -p ./rootfs/usr/share/ca-certificates/mozilla
+          cp --no-dereference /etc/ssl/certs/*.crt ./rootfs/etc/ssl/certs
+          cp --no-dereference /etc/ssl/certs/*.pem ./rootfs/etc/ssl/certs
+          cp --no-dereference /usr/share/ca-certificates/mozilla/*.crt ./rootfs/usr/share/ca-certificates/mozilla
+      
+      # Set up QEMU for multi-arch builds
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      # Log into docker hub (so we can push images)
+      -
+        name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      # Set up buildx for multi platform builds
+      -
+        name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+
+      # Build "latest"
+      - 
+        name: Build & Push - latest
+        # --push
+        run: docker buildx build --no-cache --progress plain -t "${{ env.REPO }}/${{ env.IMAGE }}:latest" --compress --platform "linux/386,linux/amd64,linux/arm/v7,linux/arm/v6,linux/arm64" .
+
+      # Get version from "latest"
+      -
+        name: Get latest image version
+        run: |
+          echo "VERSION_TAG=${GITHUB_SHA:1:7}" >> $GITHUB_ENV
+          echo "${{ env.REPO }}/${{ env.IMAGE }}:latest contains version: ${{ env.VERSION_TAG }}"
+
+      # Build version specific
+      - 
+        name: Build & Push - version specific
+        # --push
+        run: |
+          docker buildx build --progress plain -t "${{ env.REPO }}/${{ env.IMAGE }}:${{ env.VERSION_TAG }}" --compress --platform "linux/386,linux/amd64,linux/arm/v7,linux/arm/v6,linux/arm64" .
+
+      # Patch dockerfile to remove healthcheck
+      -
+        name: Patch Dockerfile to remove healthcheck
+        run: sed '/^HEALTHCHECK /d' < Dockerfile > Dockerfile.nohealthcheck
+      
+      # Build "latest_nohealthcheck"
+      - 
+        name: Build & Push - latest nohealthcheck
+        # --push
+        run: docker buildx build -f Dockerfile.nohealthcheck --no-cache --progress plain -t "${{ env.REPO }}/${{ env.IMAGE }}:latest_nohealthcheck" --compress --platform "linux/386,linux/amd64,linux/arm/v7,linux/arm/v6,linux/arm64" .
+
+      # Build version specific _nohealthcheck
+      - 
+        name: Build & Push - version specific nohealthcheck
+        # --push
+        run: |
+          docker buildx build -f Dockerfile.nohealthcheck --progress plain -t "${{ env.REPO }}/${{ env.IMAGE }}:${{ env.VERSION_TAG }}_nohealthcheck" --compress --platform "linux/386,linux/amd64,linux/arm/v7,linux/arm/v6,linux/arm64" .

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -1,7 +1,6 @@
 name: Linting
 
 on:
-  push:
   pull_request:
     branches: 
       - main

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,10 +1,9 @@
 name: Tests
 
 on:
-  push:
   pull_request:
     branches:
-      - master
+      - main
 
 jobs:
   buildx:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,20 +4,52 @@ on:
   push:
   pull_request:
     branches:
-      - main
+      - master
 
 jobs:
-
-  tests:
-
+  buildx:
+    name: Test image build
     runs-on: ubuntu-latest
-
+    strategy:
+      matrix:
+        docker-platform:
+          - linux/amd64
+          - linux/arm64
+          - linux/arm/v6
+          - linux/arm/v7
+          - linux/i386
     steps:
-    - uses: actions/checkout@v2
-    - name: Test Docker Build
-      run: docker build --no-cache . --file Dockerfile -t acarshub:testing
-    # - name: Test line_trim.sh script
-    #   run: time docker run --rm --no-healthcheck --entrypoint /scripts/test_line_trim.sh acarshub:testing
-    # - name: Test log_check.sh script
-    #   run: time docker run --rm --no-healthcheck --entrypoint /scripts/test_log_check.sh acarshub:testing
-    
+
+      # Check out our code
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+
+      # Hit an issue where arm builds would fail with cURL errors regarding intermediary certificates when downloading from github (ie: deploy-s6-overlay).
+      # After many hours of troubleshooting, the workaround is to pre-load the image's rootfs with the CA certificates from the runner.
+      # This problem may go away in future.
+      - 
+        name: Copy CA Certificates from GitHub Runner to Image rootfs
+        run: |
+          ls -la /etc/ssl/certs/
+          mkdir -p ./rootfs/etc/ssl/certs
+          mkdir -p ./rootfs/usr/share/ca-certificates/mozilla
+          cp --no-dereference /etc/ssl/certs/*.crt ./rootfs/etc/ssl/certs
+          cp --no-dereference /etc/ssl/certs/*.pem ./rootfs/etc/ssl/certs
+          cp --no-dereference /usr/share/ca-certificates/mozilla/*.crt ./rootfs/usr/share/ca-certificates/mozilla
+
+      # Set up QEMU for multi-arch builds
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      # Set up buildx for multi platform builds
+      -
+        name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+
+      # Test container build for all supported platforms (defined above)
+      - 
+        name: Build ${{ matrix.docker-platform }}
+        run: docker buildx build --no-cache --progress plain --platform ${{ matrix.docker-platform }} .

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,9 @@ ENV BRANCH_RTLSDR="ed0317e6a58c098874ac58b769cf2e609c18d9a5" \
     
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
+# Copy needs to be prior to any curl/wget so SSL certs from GitHub runner are loaded
+COPY rootfs/ /
+
 RUN set -x && \
     TEMP_PACKAGES=() && \
     KEPT_PACKAGES=() && \
@@ -115,8 +118,6 @@ RUN set -x && \
     apt-get remove -y ${TEMP_PACKAGES[@]} && \
     apt-get autoremove -y && \
     rm -rf /src/* /tmp/* /var/lib/apt/lists/* 
-
-COPY rootfs/ /
 
 ENTRYPOINT [ "/init" ]
 


### PR DESCRIPTION
- Linting & Build tests will run on PRs against main
- Deploy will run against pushes to main (ie, merge of a PR)

Build tests will test building on all supported architectures via buildx.

Deploy will build `:latest`, version specific, and also both of those without healthchecks enabled (for people running nomad).