### PR TITLE
Fix map strobe bug

### DIFF
--- a/acarshub-typescript/src/css/site.css
+++ b/acarshub-typescript/src/css/site.css
@@ -1239,8 +1239,8 @@ div.plane_element {
   color: var(--full-black);
   font-weight: bold;
   text-transform: uppercase;
-  max-width: 80px;
-  max-height: 80px;
+  max-width: 120px;
+  max-height: 120px;
   width: max-content;
   padding: 4px;
   border-radius: 15px;

--- a/acarshub-typescript/src/index.ts
+++ b/acarshub-typescript/src/index.ts
@@ -221,6 +221,8 @@ $((): void => {
           update_adsb();
         }, 5000);
       }
+    } else {
+      adsb_enabled = false;
     }
 
     // If for some reason ADSB was ever turned off on the back end and was enabled for the client, turn off the updater
@@ -524,6 +526,14 @@ export function get_match(
   tail: string = ""
 ): plane_match {
   return live_messages_page.get_match(callsign, hex, tail);
+}
+
+export function is_adsb_enabled() {
+  return adsb_enabled;
+}
+
+export function get_current_planes() {
+  return live_map_page.get_current_planes();
 }
 
 // functions that need to be registered to window object

--- a/acarshub-typescript/src/index.ts
+++ b/acarshub-typescript/src/index.ts
@@ -657,3 +657,19 @@ window.reset_alert_counts = function (): void {
     socket.emit("reset_alert_counts", { reset_alerts: true }, "/main");
   }
 };
+
+window.showPlaneMessages = function (
+  callsign: string,
+  hex: string,
+  tail: string
+): void {
+  live_map_page.showPlaneMessages(callsign, hex, tail);
+};
+
+export function showPlaneMessages(
+  plane_callsign: string = "",
+  plane_hex: string = "",
+  plane_tail: string = ""
+): void {
+  live_map_page.showPlaneMessages(plane_callsign, plane_hex, plane_tail);
+}

--- a/acarshub-typescript/src/index.ts
+++ b/acarshub-typescript/src/index.ts
@@ -598,14 +598,6 @@ window.setSort = function (sort: string = ""): void {
   live_map_page.setSort(sort);
 };
 
-window.showPlaneMessages = function (
-  callsign: string,
-  hex: string,
-  tail: string
-): void {
-  live_map_page.showPlaneMessages(callsign, hex, tail);
-};
-
 window.toggle_acars_only = function (): void {
   live_map_page.toggle_acars_only();
 };
@@ -665,11 +657,3 @@ window.reset_alert_counts = function (): void {
     socket.emit("reset_alert_counts", { reset_alerts: true }, "/main");
   }
 };
-
-export function showPlaneMessages(
-  plane_callsign: string = "",
-  plane_hex: string = "",
-  plane_tail: string = ""
-): void {
-  live_map_page.showPlaneMessages(plane_callsign, plane_hex, plane_tail);
-}

--- a/acarshub-typescript/src/interfaces.ts
+++ b/acarshub-typescript/src/interfaces.ts
@@ -211,6 +211,8 @@ export interface adsb_target {
   num_messages: number;
   messages?: acars_msg[];
   icon?: aircraft_icon;
+  position_marker: null | LeafLet.Marker;
+  datablock_marker: null | LeafLet.Marker;
 }
 
 export interface adsb_plane {

--- a/acarshub-typescript/src/interfaces.ts
+++ b/acarshub-typescript/src/interfaces.ts
@@ -210,7 +210,7 @@ export interface adsb_target {
   last_updated: number;
   num_messages: number;
   messages?: acars_msg[];
-  icon?: aircraft_icon;
+  icon: null | aircraft_icon;
   position_marker: null | LeafLet.Marker;
   datablock_marker: null | LeafLet.Marker;
 }

--- a/acarshub-typescript/src/live_map.ts
+++ b/acarshub-typescript/src/live_map.ts
@@ -660,6 +660,12 @@ export let live_map_page = {
           current_plane.lon != null
         ) {
           const callsign = this.get_callsign(current_plane);
+          if (callsign.includes("@@")) {
+            console.error(
+              "CALLSIGN CONTAINS @@. Not adding mouse hover handlers."
+            );
+            continue;
+          }
           const hex = this.get_hex(current_plane);
           const tail = this.get_tail(current_plane);
           const details = this.match_plane(plane_data, callsign, tail, hex);
@@ -674,9 +680,7 @@ export let live_map_page = {
                 this.current_hovered_from_sidebar !==
                 hex.replace("~", "").replace(".", "")
               ) {
-                this.current_hovered_from_sidebar = hex
-                  .replace("~", "")
-                  .replace(".", "");
+                this.current_hovered_from_sidebar = callsign;
                 $(
                   `#${callsign.replace("~", "").replace(".", "")}_marker`
                 ).removeClass(
@@ -814,6 +818,10 @@ export let live_map_page = {
         ) {
           const current_plane = this.adsb_planes[plane].position;
           const callsign = this.get_callsign(current_plane);
+          if (callsign.includes("@@")) {
+            console.error("CALLSIGN CONTAINS @s. Skipping target.");
+            continue;
+          }
           const rotate: number = this.get_heading(current_plane);
           const alt: string | number = this.get_alt(current_plane);
           const hex: string = this.get_hex(current_plane);

--- a/acarshub-typescript/src/live_map.ts
+++ b/acarshub-typescript/src/live_map.ts
@@ -205,13 +205,28 @@ export let live_map_page = {
         this.adsb_plane_callsign.push(this.get_callsign(aircraft));
         this.adsb_plane_tails.push(this.get_tail(aircraft));
         if (
-          this.adsb_planes[aircraft.hex.replace("~", "").toUpperCase()] ==
-          undefined
+          this.adsb_planes[
+            aircraft.hex
+              .replace("-", "")
+              .replace(".", "")
+              .replace("~", "")
+              .toUpperCase()
+          ] == undefined
         ) {
-          this.adsb_planes[aircraft.hex.replace("~", "").toUpperCase()] = {
+          this.adsb_planes[
+            aircraft.hex
+              .replace("-", "")
+              .replace(".", "")
+              .replace("~", "")
+              .toUpperCase()
+          ] = {
             position: aircraft,
             last_updated: this.last_updated,
-            id: aircraft.hex.replace("~", "").toUpperCase(),
+            id: aircraft.hex
+              .replace("-", "")
+              .replace(".", "")
+              .replace("~", "")
+              .toUpperCase(),
             num_messages: 0,
             position_marker: null,
             datablock_marker: null,
@@ -219,10 +234,18 @@ export let live_map_page = {
           };
         } else {
           this.adsb_planes[
-            aircraft.hex.replace("~", "").toUpperCase()
+            aircraft.hex
+              .replace("-", "")
+              .replace(".", "")
+              .replace("~", "")
+              .toUpperCase()
           ].position = aircraft;
           this.adsb_planes[
-            aircraft.hex.replace("~", "").toUpperCase()
+            aircraft.hex
+              .replace("-", "")
+              .replace(".", "")
+              .replace("~", "")
+              .toUpperCase()
           ].last_updated = this.last_updated;
         }
       });
@@ -498,12 +521,18 @@ export let live_map_page = {
   },
 
   get_tail: function (plane: adsb_plane): string {
-    return plane.r ? plane.r.replace("-", "") : <any>undefined;
+    return plane.r
+      ? plane.r.replace("-", "").replace(".", "").replace("~", "")
+      : <any>undefined;
   },
 
   get_hex: function (plane: adsb_plane): string {
     return plane.hex
-      ? plane.hex.replace("~", "").toUpperCase()
+      ? plane.hex
+          .replace("-", "")
+          .replace(".", "")
+          .replace("~", "")
+          .toUpperCase()
       : <any>undefined;
   },
 

--- a/acarshub-typescript/src/live_map.ts
+++ b/acarshub-typescript/src/live_map.ts
@@ -787,7 +787,7 @@ export let live_map_page = {
           num_messages,
           old_messages
         );
-        //this.set_old_messages(plane, num_messages);
+        this.set_old_messages(hex.toLowerCase(), num_messages);
         num_messages = old_messages;
       }
 
@@ -926,6 +926,19 @@ export let live_map_page = {
                 // Add in click event for showing messages
                 this.adsb_planes[plane].position_marker!.on("click", () => {
                   this.showPlaneMessages(callsign, hex, tail);
+                  const color = this.find_plane_color(
+                    callsign,
+                    alert,
+                    num_messages || 0,
+                    squawk,
+                    num_messages || 0,
+                    hex,
+                    tail
+                  );
+                  $(`#${callsign}_marker`).removeClass();
+                  $(`#${callsign}_marker`).addClass(
+                    `datablock ${color} data-jbox-content="${popup_text}`
+                  );
                 });
               }
               $(`#${callsign}_marker`).on({
@@ -972,8 +985,20 @@ export let live_map_page = {
                 // But we'll hit a snag if the plane already had a click event, so we'll remove it first
                 this.adsb_planes[plane].position_marker!.off("click");
                 this.adsb_planes[plane].position_marker!.on("click", () => {
-                  //this.adsb_planes[plane].
                   this.showPlaneMessages(callsign, hex, tail);
+                  const color = this.find_plane_color(
+                    callsign,
+                    alert,
+                    num_messages || 0,
+                    squawk,
+                    num_messages || 0,
+                    hex,
+                    tail
+                  );
+                  $(`#${callsign}_marker`).removeClass();
+                  $(`#${callsign}_marker`).addClass(
+                    `datablock ${color} data-jbox-content="${popup_text}`
+                  );
                 });
               }
             }

--- a/acarshub-typescript/src/live_map.ts
+++ b/acarshub-typescript/src/live_map.ts
@@ -691,7 +691,8 @@ export let live_map_page = {
                     squawk,
                     old_messages,
                     hex,
-                    tail
+                    tail,
+                    true
                   )
                 );
                 $(
@@ -701,9 +702,7 @@ export let live_map_page = {
             },
             mouseleave: () => {
               this.current_hovered_from_sidebar = "";
-              $(
-                `#${callsign.replace("~", "").replace(".", "")}_marker`
-              ).removeClass("airplane_orange");
+              $("div").removeClass("airplane_orange");
               $(
                 `#${callsign.replace("~", "").replace(".", "")}_marker`
               ).addClass(
@@ -724,8 +723,6 @@ export let live_map_page = {
       }
     }
     $("#num_planes").html(`Planes: ${num_planes}`);
-    // FIXME: IF THE SIDEBAR IS UPDATED AND A PLANE IS HOVERED THE STATE IS NOT RETAINED
-    // ONLY MOVING THE MOUSE WILL RESET THE HOVERED PLANE
     $("#num_planes_targets").html(`Planes w/ Targets: ${num_planes_targets}`);
   },
 
@@ -763,12 +760,14 @@ export let live_map_page = {
     squawk: number,
     old_messages: number,
     hex: string,
-    tail: string
+    tail: string,
+    skip_hovered: boolean = false
   ): string {
     let color: string = "airplane_blue";
     if (
+      !skip_hovered &&
       this.current_hovered_from_sidebar ==
-      callsign.replace("~", "").replace(".", "")
+        callsign.replace("~", "").replace(".", "")
     )
       color = "airplane_orange";
     else if (

--- a/acarshub-typescript/src/live_map.ts
+++ b/acarshub-typescript/src/live_map.ts
@@ -667,6 +667,7 @@ export let live_map_page = {
           const old_messages = this.get_old_messages(hex.toLowerCase());
           const alert = details.has_alerts;
           const squawk = this.get_sqwk(current_plane);
+
           $(`#${callsign.replace("~", "").replace(".", "")}`).on({
             mouseenter: () => {
               if (
@@ -719,6 +720,8 @@ export let live_map_page = {
       }
     }
     $("#num_planes").html(`Planes: ${num_planes}`);
+    // FIXME: IF THE SIDEBAR IS UPDATED AND A PLANE IS HOVERED THE STATE IS NOT RETAINED
+    // ONLY MOVING THE MOUSE WILL RESET THE HOVERED PLANE
     $("#num_planes_targets").html(`Planes w/ Targets: ${num_planes_targets}`);
   },
 

--- a/acarshub-typescript/src/live_messages.ts
+++ b/acarshub-typescript/src/live_messages.ts
@@ -29,9 +29,9 @@ export let live_messages_page = {
   lm_msgs_received: {
     planes: [] as plane[],
     unshift: function (a: plane) {
-      console.log(
-        `Initial number of planes w/ messages saved:  ${this.planes.length}`
-      );
+      // console.log(
+      //   `Initial number of planes w/ messages saved:  ${this.planes.length}`
+      // );
       if (this.planes.length >= 50) {
         // ADSB is off so we don't need to be all clever like removing the last element
         if (!is_adsb_enabled()) {
@@ -48,15 +48,15 @@ export let live_messages_page = {
                 current_planes_adsb.tail.includes(identifier)
               ) {
                 delete_index = false;
-                console.log(`saving plane with ${identifier}`);
+                // console.log(`saving plane with ${identifier}`);
                 return false;
               }
               return true;
             });
             if (delete_index) {
-              console.log(
-                `deleting a plane (${this.planes[i].identifiers}).....`
-              );
+              // console.log(
+              //   `deleting a plane (${this.planes[i].identifiers}).....`
+              // );
               indexes_to_delete.push(i);
             }
           }
@@ -71,9 +71,9 @@ export let live_messages_page = {
             });
         }
       }
-      console.log(
-        `Final number of planes w/ messages saved: ${this.planes.length + 1}`
-      );
+      // console.log(
+      //   `Final number of planes w/ messages saved: ${this.planes.length + 1}`
+      // );
       return Array.prototype.unshift.apply(this.planes, [a]);
     },
     get_all_messages: function (): acars_msg[][] {

--- a/acarshub-typescript/src/live_messages.ts
+++ b/acarshub-typescript/src/live_messages.ts
@@ -15,7 +15,13 @@ import {
 import jBox from "jbox";
 //i mport "jbox/dist/jBox.all.css";
 import { tooltip } from "./tooltips";
-import { resize_tabs, match_alert, sound_alert } from "./index";
+import {
+  resize_tabs,
+  match_alert,
+  sound_alert,
+  is_adsb_enabled,
+  get_current_planes,
+} from "./index";
 
 export let live_messages_page = {
   pause: false as boolean,
@@ -23,17 +29,62 @@ export let live_messages_page = {
   lm_msgs_received: {
     planes: [] as plane[],
     unshift: function (a: plane) {
+      console.log(
+        `Initial number of planes w/ messages saved:  ${this.planes.length}`
+      );
       if (this.planes.length >= 50) {
-        this.planes.pop();
+        // ADSB is off so we don't need to be all clever like removing the last element
+        if (!is_adsb_enabled()) {
+          this.planes.pop();
+        } else {
+          let indexes_to_delete: Array<number> = [];
+          const current_planes_adsb = get_current_planes();
+          for (let i = 49; i < this.planes.length; i++) {
+            let delete_index = true;
+            this.planes[i].identifiers.every((identifier) => {
+              if (
+                current_planes_adsb.hex.includes(identifier) ||
+                current_planes_adsb.callsigns.includes(identifier) ||
+                current_planes_adsb.tail.includes(identifier)
+              ) {
+                delete_index = false;
+                console.log(`saving plane with ${identifier}`);
+                return false;
+              }
+              return true;
+            });
+            if (delete_index) {
+              console.log(
+                `deleting a plane (${this.planes[i].identifiers}).....`
+              );
+              indexes_to_delete.push(i);
+            }
+          }
+          // delete the selected indexes from this.planes
+          // sorting the list descending because we want to keep
+          // the indexes true to the original indexes and deleting from the front
+          // of the list would cause invalid indexes as we walked the array
+          indexes_to_delete
+            .sort((a, b) => b - a)
+            .forEach((index) => {
+              this.planes.splice(index, 1);
+            });
+        }
       }
+      console.log(
+        `Final number of planes w/ messages saved: ${this.planes.length + 1}`
+      );
       return Array.prototype.unshift.apply(this.planes, [a]);
     },
     get_all_messages: function (): acars_msg[][] {
       let output = [] as acars_msg[][];
       for (const msgList of this.planes) {
-        output.push(msgList.messages);
+        if (output.length < 50) {
+          output.push(msgList.messages);
+        } else {
+          return output;
+        }
       }
-
       return output;
     },
   },

--- a/rootfs/webapp/acarshub.py
+++ b/rootfs/webapp/acarshub.py
@@ -79,7 +79,7 @@ def update_keys(json_message):
     if (
         "flight" in json_message
         and json_message["flight"] is not None
-        and "icao_hex" in json_message.keys()
+        and "icao_hex" in json_message
     ):
         json_message["flight"], json_message["icao_flight"] = flight_finder(
             callsign=json_message["flight"], hex_code=json_message["icao_hex"]

--- a/version
+++ b/version
@@ -1,2 +1,2 @@
-v2.7.1 Build 1081
-v2.7.1Build1081
+v2.7.2 Build 1082
+v2.7.2Build1082


### PR DESCRIPTION
This update is focused on reducing "map-strobing" with large amounts of ADSB targets (old messages expiring) and general map speed improvements.

* ACARS Hub will no longer dump a message group if ADSB targets are present
* Map no longer runs `update_targets()` during plane list hover events
* Map now updates color of airplane target immediately after clicking on the target to view messages
* Scrolling is now MUCH faster
* Extended datablocks properly size themselves
* Much speedier to pull up messages when you click a target on the map
* Invalid characters in the ICAO hex won't kill ACARS Hub