### PR TITLE
Message matching and alert ignore

### DIFF
--- a/acarshub-typescript/package-lock.json
+++ b/acarshub-typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "acarshub-typescript",
-  "version": "2.8.2",
+  "version": "2.9.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "acarshub-typescript",
-      "version": "2.8.2",
+      "version": "2.9.0",
       "license": "GPL-3.0-only",
       "dependencies": {
         "@airframes/acars-decoder": "^1.1.0",
@@ -27,7 +27,7 @@
         "socket.io-client": "4.4.1"
       },
       "devDependencies": {
-        "@babel/core": "^7.16.10",
+        "@babel/core": "^7.16.12",
         "@babel/preset-env": "^7.16.11",
         "@types/jquery": "^3.5.13",
         "@types/js-cookie": "^3.0.1",
@@ -93,9 +93,9 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.16.10",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.16.10.tgz",
-      "integrity": "sha512-pbiIdZbCiMx/MM6toR+OfXarYix3uz0oVsnNtfdAGTcCTu3w/JGF8JhirevXLBJUu0WguSZI12qpKnx7EeMyLA==",
+      "version": "7.16.12",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.16.12.tgz",
+      "integrity": "sha512-dK5PtG1uiN2ikk++5OzSYsitZKny4wOCD0nrO4TqnW4BVBTQ2NGS3NgilvT/TEyxTST7LNyWV/T4tXDoD3fOgg==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.16.7",
@@ -103,7 +103,7 @@
         "@babel/helper-compilation-targets": "^7.16.7",
         "@babel/helper-module-transforms": "^7.16.7",
         "@babel/helpers": "^7.16.7",
-        "@babel/parser": "^7.16.10",
+        "@babel/parser": "^7.16.12",
         "@babel/template": "^7.16.7",
         "@babel/traverse": "^7.16.10",
         "@babel/types": "^7.16.8",
@@ -489,9 +489,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.16.10",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.16.10.tgz",
-      "integrity": "sha512-Sm/S9Or6nN8uiFsQU1yodyDW3MWXQhFeqzMPM+t8MJjM+pLsnFVxFZzkpXKvUXh+Gz9cbMoYYs484+Jw/NTEFQ==",
+      "version": "7.16.12",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.16.12.tgz",
+      "integrity": "sha512-VfaV15po8RiZssrkPweyvbGVSe4x2y+aciFCgn0n0/SJMR22cwofRV1mtnJQYcSB1wUTaA/X1LnA3es66MCO5A==",
       "dev": true,
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -10105,9 +10105,9 @@
       "dev": true
     },
     "@babel/core": {
-      "version": "7.16.10",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.16.10.tgz",
-      "integrity": "sha512-pbiIdZbCiMx/MM6toR+OfXarYix3uz0oVsnNtfdAGTcCTu3w/JGF8JhirevXLBJUu0WguSZI12qpKnx7EeMyLA==",
+      "version": "7.16.12",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.16.12.tgz",
+      "integrity": "sha512-dK5PtG1uiN2ikk++5OzSYsitZKny4wOCD0nrO4TqnW4BVBTQ2NGS3NgilvT/TEyxTST7LNyWV/T4tXDoD3fOgg==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.16.7",
@@ -10115,7 +10115,7 @@
         "@babel/helper-compilation-targets": "^7.16.7",
         "@babel/helper-module-transforms": "^7.16.7",
         "@babel/helpers": "^7.16.7",
-        "@babel/parser": "^7.16.10",
+        "@babel/parser": "^7.16.12",
         "@babel/template": "^7.16.7",
         "@babel/traverse": "^7.16.10",
         "@babel/types": "^7.16.8",
@@ -10404,9 +10404,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.16.10",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.16.10.tgz",
-      "integrity": "sha512-Sm/S9Or6nN8uiFsQU1yodyDW3MWXQhFeqzMPM+t8MJjM+pLsnFVxFZzkpXKvUXh+Gz9cbMoYYs484+Jw/NTEFQ==",
+      "version": "7.16.12",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.16.12.tgz",
+      "integrity": "sha512-VfaV15po8RiZssrkPweyvbGVSe4x2y+aciFCgn0n0/SJMR22cwofRV1mtnJQYcSB1wUTaA/X1LnA3es66MCO5A==",
       "dev": true
     },
     "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": {

--- a/acarshub-typescript/package.json
+++ b/acarshub-typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "acarshub-typescript",
-  "version": "2.8.2",
+  "version": "2.9.0",
   "description": "Web front end for the docker-acarshub project",
   "main": "index.js",
   "repository": "https://github.com/fredclausen/docker-acarshub",
@@ -13,7 +13,7 @@
   "author": "Fred Clausen",
   "license": "GPL-3.0-only",
   "devDependencies": {
-    "@babel/core": "^7.16.10",
+    "@babel/core": "^7.16.12",
     "@babel/preset-env": "^7.16.11",
     "@types/jquery": "^3.5.13",
     "@types/js-cookie": "^3.0.1",

--- a/acarshub-typescript/src/index.ts
+++ b/acarshub-typescript/src/index.ts
@@ -504,13 +504,17 @@ export function alert_term_query(
   );
 }
 
-export function alert_text_update(alert_text: string[]): void {
+export function alert_text_update(
+  alert_text: string[],
+  ignore_text: string[]
+): void {
   socket.emit(
     "update_alerts",
     {
       terms: alert_text,
+      ignore: ignore_text,
     },
-    "/alerts"
+    "/main"
   );
 }
 

--- a/acarshub-typescript/src/index.ts
+++ b/acarshub-typescript/src/index.ts
@@ -718,6 +718,10 @@ window.showPlaneMessages = function (
   hex: string,
   tail: string
 ): void {
+  if (hex === undefined) {
+    console.error("ERROR", callsign, tail);
+    return;
+  }
   live_map_page.showPlaneMessages(callsign, hex, tail);
 };
 

--- a/acarshub-typescript/src/interfaces.ts
+++ b/acarshub-typescript/src/interfaces.ts
@@ -48,6 +48,7 @@ export interface status_global {
 
 export interface terms {
   terms: string[];
+  ignore: string[];
 }
 
 export interface decoders {

--- a/acarshub-typescript/src/pages/alerts.ts
+++ b/acarshub-typescript/src/pages/alerts.ts
@@ -430,6 +430,7 @@ export let alerts_page = {
         stack: true,
         delayOnHover: true,
         showCountdown: true,
+        closeOnClick: true,
         animation: {
           open: "zoomIn",
           close: "zoomIn",

--- a/acarshub-typescript/src/pages/alerts.ts
+++ b/acarshub-typescript/src/pages/alerts.ts
@@ -1,6 +1,14 @@
 import Cookies from "js-cookie";
-import { display_messages } from "../helpers/html_generator";
-import { alert_term_query, alert_text_update } from "../index";
+import {
+  display_messages,
+  display_message_group,
+} from "../helpers/html_generator";
+import {
+  alert_term_query,
+  alert_text_update,
+  get_window_size,
+  resize_tabs,
+} from "../index";
 import { acars_msg, alert_matched, html_msg, terms } from "../interfaces";
 import jBox from "jbox";
 //import "jbox/dist/jBox.all.css";
@@ -420,9 +428,14 @@ export let alerts_page = {
       found &&
       (typeof msg.loading === "undefined" || !msg.loading)
     ) {
+      // get random number between 1000 and 10000000000
+      const random_number = String(
+        Math.floor(Math.random() * (1000000000 - 1000 + 1)) + 1000
+      );
       const msg_text: string =
         "A new message matched with the following term(s): " + term_string;
       new jBox("Notice", {
+        id: "alert_popup_" + random_number,
         attributes: {
           x: "right",
           y: "bottom",
@@ -430,13 +443,35 @@ export let alerts_page = {
         stack: true,
         delayOnHover: true,
         showCountdown: true,
-        closeOnClick: true,
         animation: {
           open: "zoomIn",
           close: "zoomIn",
         },
         content: msg_text,
         color: "green",
+        autoClose: 10000,
+      });
+
+      $("#alert_popup_" + random_number).on("click", () => {
+        const window_size = get_window_size();
+        console.log(window_size);
+        let box = new jBox("Modal", {
+          id: "set_modal" + random_number,
+          blockScroll: false,
+          isolateScroll: true,
+          animation: "zoomIn",
+          closeButton: "box",
+          overlay: false,
+          reposition: true,
+          repositionOnOpen: false,
+          title: "Messages",
+          content:
+            `<div id="msg${random_number}">` +
+            display_message_group([msg.msghtml]) +
+            "</div>",
+        });
+        box.open();
+        resize_tabs();
       });
     }
 

--- a/acarshub-typescript/src/pages/live_map.ts
+++ b/acarshub-typescript/src/pages/live_map.ts
@@ -613,6 +613,10 @@ export let live_map_page = {
       const squawk = this.get_sqwk(current_plane);
       const callsign = this.get_callsign(current_plane);
       const hex = this.get_hex(current_plane);
+      if (hex === undefined) {
+        console.error("NO HEX FOUND");
+        continue;
+      }
       plane_callsigns.push({ callsign: callsign, hex: hex });
       const tail: string = this.get_tail(current_plane);
       const baro_rate = this.get_baro_rate(current_plane);
@@ -728,6 +732,10 @@ export let live_map_page = {
             continue;
           }
           const hex = this.get_hex(current_plane);
+          if (hex === undefined) {
+            console.error("NO HEX FOR PLANE");
+            continue;
+          }
           const tail = this.get_tail(current_plane);
           const details = this.match_plane(plane_data, callsign, tail, hex);
           const num_messages = details.num_messages;
@@ -872,6 +880,10 @@ export let live_map_page = {
           const rotate: number = this.get_heading(current_plane);
           const alt: string | number = this.get_alt(current_plane);
           const hex: string = this.get_hex(current_plane);
+          if (hex === undefined) {
+            console.error("NO HEX FOR PLANE");
+            continue;
+          }
           const speed: number = this.get_speed(current_plane);
           const squawk: number = this.get_sqwk(current_plane);
           const baro_rate: number = this.get_baro_rate(current_plane);
@@ -1136,6 +1148,10 @@ export let live_map_page = {
       const current_plane = this.adsb_planes[plane].position;
       const callsign = this.get_callsign(current_plane);
       const hex: string = this.get_hex(current_plane);
+      if (hex === undefined) {
+        console.error("NO HEX FOR PLANE");
+        continue;
+      }
       const tail: string = this.get_tail(current_plane);
       const details = this.match_plane(plane_data, callsign, tail, hex);
       const num_messages = details.num_messages;

--- a/rootfs/webapp/acarshub_db.py
+++ b/rootfs/webapp/acarshub_db.py
@@ -156,6 +156,12 @@ class alertStats(Messages):
     count = Column("count", Integer)
 
 
+class ignoreAlertTerms(Messages):
+    __tablename__ = "ignore_alert_terms"
+    id = Column(Integer(), primary_key=True)
+    term = Column("term", String(32))
+
+
 # Class to store our messages
 
 
@@ -1038,6 +1044,9 @@ def get_alert_counts():
             return result_list
     except Exception as e:
         acarshub_helpers.acars_traceback(e, "database")
+
+
+# def set_alert_ignore(terms: None):
 
 
 def set_alert_terms(terms=None):

--- a/rootfs/webapp/application.py
+++ b/rootfs/webapp/application.py
@@ -538,7 +538,10 @@ def main_connect():
 
         socketio.emit(
             "terms",
-            {"terms": acarshub.acarshub_db.get_alert_terms()},
+            {
+                "terms": acarshub.acarshub_db.get_alert_terms(),
+                "ignore": acarshub.acarshub_db.get_alert_ignore(),
+            },
             to=requester,
             namespace="/main",
         )

--- a/rootfs/webapp/application.py
+++ b/rootfs/webapp/application.py
@@ -602,7 +602,12 @@ def main_connect():
             to=requester,
             namespace="/main",
         )
-        socketio.emit("alert_terms", {"data": acarshub.getAlerts()}, namespace="/main")
+        socketio.emit(
+            "alert_terms",
+            {"data": acarshub.getAlerts()},
+            to=requester,
+            namespace="/main",
+        )
         send_version()
     except Exception as e:
         acarshub_helpers.log(
@@ -645,6 +650,7 @@ def get_alerts(message, namespace):
 @socketio.on("update_alerts", namespace="/main")
 def update_alerts(message, namespace):
     acarshub.acarshub_db.set_alert_terms(message["terms"])
+    acarshub.acarshub_db.set_alert_ignore(message["ignore"])
 
 
 @socketio.on("signal_freqs", namespace="/main")
@@ -715,7 +721,16 @@ def handle_message(message, namespace):
 @socketio.on("reset_alert_counts", namespace="/main")
 def reset_alert_counts(message, namespace):
     if message["reset_alerts"]:
+        requester = request.sid
         acarshub.acarshub_db.reset_alert_counts()
+        try:
+            socketio.emit(
+                "alert_terms", {"data": acarshub.getAlerts()}, namespace="/main"
+            )
+        except Exception as e:
+            acarshub_helpers.log(
+                f"Main Connect: Error sending alert_terms: {e}", "webapp"
+            )
 
 
 @socketio.on("disconnect", namespace="/main")

--- a/version
+++ b/version
@@ -1,2 +1,2 @@
-v2.8.2 Build 1088
-v2.8.2Build1088
+v2.9.0 Build 1089
+v2.9.0Build1089


### PR DESCRIPTION
Bug Fixes:
* Message matching works again. Sorry, I broke it "optimizing" things
* All users with an active web session will get the updated alert terms if another updates them

New:
* You can add a list of words to ignore, even if a match is generated. For example, if you are monitoring the term `TURBULENCE` but don't want to see alerts about `LIGHT TURBULENCE` you could add either `LIGHT` or `LIGHT TURBULENCE` to the ignore list. The difference between the two would be that in the first case if `LIGHT` appeared ANYWHERE in the text field the message would be ignored, but in the second case the message would be rejected only if the entire phrase `LIGHT TURBULENCE` appears in the message.
* If an alert generates a notice on the bottom right you can now click on the notice and view the message that generated the alert.