### PR TITLE
Fix: Update acarshub to support dual stack

### DIFF
--- a/rootfs/etc/nginx.acarshub/sites-enabled/acarshub
+++ b/rootfs/etc/nginx.acarshub/sites-enabled/acarshub
@@ -1,5 +1,6 @@
 server {
   listen 80 default_server;
+  listen [::]:80 default_server;
 
   root /webapp/dist;
   server_name _;


### PR DESCRIPTION
acarshub only supports ipv4 right now.  This update allows acarshub to support dual stack.