### PR TITLE
chore(flake/nixpkgs): `567a49d1` -> `b5aa0fbd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -162,11 +162,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1781577229,
-        "narHash": "sha256-lrp67w8AulE9Ks53n27I45ADSzbOCn4H+CNW1Ck8B+8=",
+        "lastModified": 1782723713,
+        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "567a49d1913ce81ac6e9582e3553dd90a955875f",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                                                            |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
| [`f2f19ead`](https://github.com/NixOS/nixpkgs/commit/f2f19ead8473cbebfba300aa6f3e2a13fd18beac) | `` statix: enable __structuredAttrs ``                                                                                             |
| [`95d7dce8`](https://github.com/NixOS/nixpkgs/commit/95d7dce80bdb33fba9dd9d9d00f5e1f1943cef59) | `` statix: 0.5.8-unstable-2026-06-22 -> 0.5.8-unstable-2026-06-28 ``                                                               |
| [`9e78032e`](https://github.com/NixOS/nixpkgs/commit/9e78032e69c9c84e4ad8d47299e5ffd0d47ff10e) | `` goldendict-ng: 26.6.0 -> 26.6.1 ``                                                                                              |
| [`8c1ad1b1`](https://github.com/NixOS/nixpkgs/commit/8c1ad1b1a9976b5d40a343f33da90bd6e77942be) | `` azure-cli-extensions.azure-devops: 1.0.4 -> 1.0.5 ``                                                                            |
| [`23c43fd6`](https://github.com/NixOS/nixpkgs/commit/23c43fd69dab28dfd62f54af3bfe977bfc199bc0) | `` python3Packages.pybase62: fix hash ``                                                                                           |
| [`863a9781`](https://github.com/NixOS/nixpkgs/commit/863a97812cbf74a10b6d0ab77c66c870423e3bee) | `` zed-editor: 1.7.2 -> 1.8.2 ``                                                                                                   |
| [`462b84b9`](https://github.com/NixOS/nixpkgs/commit/462b84b95196861780a9f92561cbc850ba912fdb) | `` libretro.beetle-pce-fast: 0-unstable-2026-05-22 -> 0-unstable-2026-06-26 ``                                                     |
| [`1eb05866`](https://github.com/NixOS/nixpkgs/commit/1eb058667ca146942965d015b5bd9a4f7b4ba822) | `` models-dev: 0-unstable-2026-06-20 -> 0-unstable-2026-06-29 ``                                                                   |
| [`8ef16b53`](https://github.com/NixOS/nixpkgs/commit/8ef16b532652f44eb4973b099ccfb96761bc454f) | `` herdr: 0.7.0 -> 0.7.1 ``                                                                                                        |
| [`85237867`](https://github.com/NixOS/nixpkgs/commit/85237867d89aa523c1dba0bf55ee0a240b189b03) | `` python3Packages.lark-oapi: 1.6.8 -> 1.6.9 ``                                                                                    |
| [`2bda559e`](https://github.com/NixOS/nixpkgs/commit/2bda559e41c0363b33866c1baa9b87046773566a) | `` python3Packages.aiointercept: 0.1.7 -> 0.1.8 ``                                                                                 |
| [`88f91a9c`](https://github.com/NixOS/nixpkgs/commit/88f91a9c03568d8eeb40f68bed797f906492facf) | `` worldpainter: 2.26.2 -> 2.27.0 ``                                                                                               |
| [`c7204eaa`](https://github.com/NixOS/nixpkgs/commit/c7204eaae30ced8c969d8a37364ec0c063daa7e0) | `` oxlint: 1.70.0 -> 1.71.0 ``                                                                                                     |
| [`09629df5`](https://github.com/NixOS/nixpkgs/commit/09629df54347cd86a80e325366b8fbcf1ce78011) | `` home-assistant-custom-components.waste_collection_schedule: 2.28.0 -> 2.29.0 ``                                                 |
| [`1e70b067`](https://github.com/NixOS/nixpkgs/commit/1e70b067d408b3404a1242b269a2e8135286895a) | `` python3Packages.boschshcpy: 0.2.122 -> 0.3.19 ``                                                                                |
| [`ee98b4e5`](https://github.com/NixOS/nixpkgs/commit/ee98b4e53a316d89c0a4236034a6899ad71b95fa) | `` arping: 2.28 -> 2.29 ``                                                                                                         |
| [`bc001b93`](https://github.com/NixOS/nixpkgs/commit/bc001b932de6cbaf62177e90251f51dc2f48774d) | `` sequoia-sqv: 1.3.0 -> 1.4.0 ``                                                                                                  |
| [`ccde9ed9`](https://github.com/NixOS/nixpkgs/commit/ccde9ed9669549fcf105b31acfba47416693c12f) | `` zlequalizer: 1.2.1 -> 1.2.2 ``                                                                                                  |
| [`8a09c8c2`](https://github.com/NixOS/nixpkgs/commit/8a09c8c270d25b90744162e38aa97290a7a82a26) | `` gogup: 1.3.0 -> 1.7.1 ``                                                                                                        |
| [`313efb23`](https://github.com/NixOS/nixpkgs/commit/313efb23af8e03983e54fd03722eb9b00300a6e7) | `` python3Packages.jaxopt: skip failing test ``                                                                                    |
| [`9bfe1d64`](https://github.com/NixOS/nixpkgs/commit/9bfe1d640b69364e30696f6500f50c2fe550f44d) | `` python3Packages.blackjax: skip failing test ``                                                                                  |
| [`183181af`](https://github.com/NixOS/nixpkgs/commit/183181afcced85163485f63997bc4fa967daaceb) | `` python3Packages.flax: fix test with new jax ``                                                                                  |
| [`defc2a79`](https://github.com/NixOS/nixpkgs/commit/defc2a792694e42368bf3d0b0256d18f5f2cc435) | `` python3Packages.orbax-checkpoint: 0.11.40 -> 0.12.1 ``                                                                          |
| [`1c8d0fb8`](https://github.com/NixOS/nixpkgs/commit/1c8d0fb81872e5b28209a5407b391e9994093ec9) | `` home-assistant-custom-lovelace-modules.atomic-calendar-revive: 10.3.0 -> 10.3.1 ``                                              |
| [`e4deb70c`](https://github.com/NixOS/nixpkgs/commit/e4deb70c8939bd1fa152ea73bed71aee36015b68) | `` python3Packages.llama-index-workflows: 2.22.0 -> 2.22.1 ``                                                                      |
| [`d497224d`](https://github.com/NixOS/nixpkgs/commit/d497224d5af025ff32c3237510b08dfb3214d1f0) | `` par-lang: 0-unstable-2026-06-11 -> 0-unstable-2026-06-24 ``                                                                     |
| [`58d658e1`](https://github.com/NixOS/nixpkgs/commit/58d658e120821f5585bfbd7078a1509511a6c3d4) | `` odp-dpdk: add stepbrodb to maintainers ``                                                                                       |
| [`27a5de5f`](https://github.com/NixOS/nixpkgs/commit/27a5de5f15f9826255681729f4339213c7914de0) | `` odp-dpdk: 1.46.0.0_DPDK_22.11 -> 1.50.0.0_DPDK_24.11 ``                                                                         |
| [`321a3bf3`](https://github.com/NixOS/nixpkgs/commit/321a3bf3397dec86b31f7ddf073c7d45a504912d) | `` libretro.stella: 0-unstable-2026-06-19 -> 0-unstable-2026-06-28 ``                                                              |
| [`c57504fe`](https://github.com/NixOS/nixpkgs/commit/c57504fe36dd384cbb77324f670dbace175344e9) | `` pktgen: add stepbrodb to maintainers ``                                                                                         |
| [`1baf495c`](https://github.com/NixOS/nixpkgs/commit/1baf495cd74251d579be979c2ac5438dadd6b91f) | `` pktgen: 24.10.3 -> 26.03.0 ``                                                                                                   |
| [`7f81f12b`](https://github.com/NixOS/nixpkgs/commit/7f81f12bc73e36d7bf76e944b7fd2156edf6dd44) | `` dpdk: add stepbrodb to maintainers ``                                                                                           |
| [`4c06c426`](https://github.com/NixOS/nixpkgs/commit/4c06c426639bb79834a542e35fe1c1b4e2f8c273) | `` dpdk: 25.07 -> 26.03 ``                                                                                                         |
| [`bd07fdc9`](https://github.com/NixOS/nixpkgs/commit/bd07fdc953fbce1f7ec94d45622ff69e7e3c6dac) | `` monkeys-audio: 13.06 -> 13.13 ``                                                                                                |
| [`b49b0ece`](https://github.com/NixOS/nixpkgs/commit/b49b0ecef1aece2bffda0bd62a008ea26789f311) | `` python3Packages.elevenlabs: 2.53.0 -> 2.54.0 ``                                                                                 |
| [`7c4cef96`](https://github.com/NixOS/nixpkgs/commit/7c4cef965a943c8179076efd2b02135dd90cd56e) | `` python3Packages.google-cloud-language: migrate to finalAttrs ``                                                                 |
| [`1602a466`](https://github.com/NixOS/nixpkgs/commit/1602a466a1d0442af22e0284a0e12260fbc920c8) | `` buildDubPackage: default `__structuredAttrs` to true ``                                                                         |
| [`b5ce98ef`](https://github.com/NixOS/nixpkgs/commit/b5ce98eff275f654b9a95674629f6509e59c6464) | `` buildDubPackage: remove-references to all outputs of `compiler` ``                                                              |
| [`d7c50a53`](https://github.com/NixOS/nixpkgs/commit/d7c50a53252f59a67619058d3fb315d7b663f855) | `` home-assistant-custom-components.home_connect_alt: 1.4.1 -> 1.4.2 ``                                                            |
| [`3f3a2964`](https://github.com/NixOS/nixpkgs/commit/3f3a29643f8257b5732b7cf59bfa7b8e834939cc) | `` gtree: 1.14.2 -> 1.14.5 ``                                                                                                      |
| [`99f3b0d3`](https://github.com/NixOS/nixpkgs/commit/99f3b0d320df697890bc977705d24472211bfae5) | `` diffoscope: fix tests ``                                                                                                        |
| [`9d5af9d5`](https://github.com/NixOS/nixpkgs/commit/9d5af9d5c8ca80d4cd09e292b6ef51f2437dea4f) | `` libretro.pcsx-rearmed: 0-unstable-2026-06-13 -> 0-unstable-2026-06-28 ``                                                        |
| [`729aed72`](https://github.com/NixOS/nixpkgs/commit/729aed726be7196ed697b5208c052b1e3e7e41ea) | `` ntpd-rs: skip more tests on darwin ``                                                                                           |
| [`3c14c2c2`](https://github.com/NixOS/nixpkgs/commit/3c14c2c266a4b82840b72abe7571e3c751dbf925) | `` python3Packages.dsmr-parser: 1.9.0 -> 1.11.0 ``                                                                                 |
| [`67ebf03c`](https://github.com/NixOS/nixpkgs/commit/67ebf03c9ff8b36e7c76da49a9561637cc92ed9f) | `` ente-desktop: 1.7.22 -> 1.7.24 ``                                                                                               |
| [`c23c3a55`](https://github.com/NixOS/nixpkgs/commit/c23c3a5516d43112f03f573169faf66bda6335d0) | `` pgdog: 0.1.45 -> 0.1.46 ``                                                                                                      |
| [`1a0fe662`](https://github.com/NixOS/nixpkgs/commit/1a0fe662869eb17d3438430b468b3d20dca6d200) | `` codebase-memory-mcp: build web ui ``                                                                                            |
| [`2b3763c3`](https://github.com/NixOS/nixpkgs/commit/2b3763c395207f46aaf0910033d5a64e480ece5f) | `` codebase-memory-mcp: build parallel again ``                                                                                    |
| [`71c36646`](https://github.com/NixOS/nixpkgs/commit/71c36646dd32fa5f99ec2421129ccf4c83e741b1) | `` vscode-extensions.databricks.databricks: 2.11.1 -> 2.12.0 ``                                                                    |
| [`f91bc654`](https://github.com/NixOS/nixpkgs/commit/f91bc654080da391318a4a680f8636343e0a23e4) | `` terraform-providers.sysdiglabs_sysdig: 3.8.1 -> 3.8.2 ``                                                                        |
| [`4a5a56bc`](https://github.com/NixOS/nixpkgs/commit/4a5a56bca2b0766661ebfb45e717f6e38957a74b) | `` botamusique: drop ``                                                                                                            |
| [`48447120`](https://github.com/NixOS/nixpkgs/commit/48447120b4b79072d15e8b899296529ec629e607) | `` whichllm: 0.5.12 -> 0.5.13 ``                                                                                                   |
| [`4b15247c`](https://github.com/NixOS/nixpkgs/commit/4b15247cf2654f363661d35295cad0388f4d7a7c) | `` ndg: 2.8.0 -> 2.9.0 ``                                                                                                          |
| [`0562ace3`](https://github.com/NixOS/nixpkgs/commit/0562ace3b5d97859299f5f1d565a6183a4800240) | `` python3Packages.pykwb: modernize ``                                                                                             |
| [`ac290539`](https://github.com/NixOS/nixpkgs/commit/ac29053902dcd0d02605d2d1e0bfbfb7bd4a3ffe) | `` terraform-providers.splunk-terraform_signalfx: 9.30.2 -> 9.30.3 ``                                                              |
| [`558c2869`](https://github.com/NixOS/nixpkgs/commit/558c28699212d45f85208c70f6639f2343522904) | `` abella: migrate to by-name ``                                                                                                   |
| [`cfd5429d`](https://github.com/NixOS/nixpkgs/commit/cfd5429d2119e051625f27317f9dc01b2856c9e2) | `` claude-monitor: 3.1.0 -> 4.0.0 ``                                                                                               |
| [`d1293cad`](https://github.com/NixOS/nixpkgs/commit/d1293cadd93233df5723d586eb9bc26ca8bb36c1) | `` abella: move all args out of top-level, refactor ``                                                                             |
| [`04e31ca1`](https://github.com/NixOS/nixpkgs/commit/04e31ca14a42f0b1f83d1498f5ba2f5db7c4a64f) | `` rift-wm: init at 0.4.3 ``                                                                                                       |
| [`3b217131`](https://github.com/NixOS/nixpkgs/commit/3b217131407a08b1b3b016856439d0f5cc802d2a) | `` python3Packages.pykwb: 0.0.10 -> 0.0.21 ``                                                                                      |
| [`555349c5`](https://github.com/NixOS/nixpkgs/commit/555349c5d2395bc14720272ba1cc172d6ddf58c8) | `` openroad: removed unused pcre dependency ``                                                                                     |
| [`f212032b`](https://github.com/NixOS/nixpkgs/commit/f212032b09cf2d2d6be511ceb3e949bc2bf00eb3) | `` cargo-shear: 1.12.4 -> 1.13.1 ``                                                                                                |
| [`dec98d9b`](https://github.com/NixOS/nixpkgs/commit/dec98d9bf38630c5aa3617f3e60852bff9dd19cb) | `` python3Packages.google-cloud-language: 2.20.0 -> 2.21.0 ``                                                                      |
| [`03b08f64`](https://github.com/NixOS/nixpkgs/commit/03b08f64803d605dd8d4934fb8dd4740d69a79f0) | `` codebase-memory-mcp: disable updater and install/uninstall ``                                                                   |
| [`fc5b5fc9`](https://github.com/NixOS/nixpkgs/commit/fc5b5fc962871e9dcde3370d9dc315b40a627767) | `` emacsPackages.ghostel: 0.35.4-unstable-2026-06-19 -> 0.39.0-unstable-2026-06-26 ``                                              |
| [`4de1f3c8`](https://github.com/NixOS/nixpkgs/commit/4de1f3c866d66740ab232afe544b5bf48ed8fe6a) | `` gefyra: 2.5.1 -> 2.5.2 ``                                                                                                       |
| [`93263c00`](https://github.com/NixOS/nixpkgs/commit/93263c0068f20064b9bf8f980f2e5b5fd32f1535) | `` linphonePackages.mediastreamer2: add libsm to propagatedBuildInputs ``                                                          |
| [`f996d69b`](https://github.com/NixOS/nixpkgs/commit/f996d69b98daf1c220cb78ac362bca8867011f25) | `` invidious: enable __structuredAttrs ``                                                                                          |
| [`aee5b69e`](https://github.com/NixOS/nixpkgs/commit/aee5b69ef10d35f92d6af28396d76dc32b7245dc) | `` python3Packges.lacuscore: migrate to finalAttrs ``                                                                              |
| [`dd0d482d`](https://github.com/NixOS/nixpkgs/commit/dd0d482ddb1b26d88937c6367eed31bceb5c1295) | `` python3Packages.iamdata: 0.1.202606271 -> 0.1.202606281 ``                                                                      |
| [`53f74469`](https://github.com/NixOS/nixpkgs/commit/53f74469c3f4d814f4165172b59c8a96ddb04311) | `` invidious: 2.20260207.0 -> 2.20260626.0 ``                                                                                      |
| [`a0656f79`](https://github.com/NixOS/nixpkgs/commit/a0656f797f4bfa0bca53036552be370bdd9af763) | `` terraform-providers.hashicorp_azurerm: 4.76.0 -> 4.79.0 ``                                                                      |
| [`a65fda26`](https://github.com/NixOS/nixpkgs/commit/a65fda26ccc4f49ab7e8bd3436fd90d2f6d2b6bb) | `` python3Packages.databricks-sdk: 0.118.0 -> 0.119.0 ``                                                                           |
| [`35edb8aa`](https://github.com/NixOS/nixpkgs/commit/35edb8aaa8caccd963c9428d4d93148f2e7e81da) | `` opencloud.web: 7.1.0 -> 7.1.2 ``                                                                                                |
| [`cb262ee0`](https://github.com/NixOS/nixpkgs/commit/cb262ee05de93b8998123b04668c0b2f5deed637) | `` opencloud: 7.1.0 -> 7.2.0 ``                                                                                                    |
| [`0b9cbdeb`](https://github.com/NixOS/nixpkgs/commit/0b9cbdebbaad1ebeda5710570e0b0cfd6a663161) | `` invidious: fix update script ``                                                                                                 |
| [`4c9314a3`](https://github.com/NixOS/nixpkgs/commit/4c9314a3739a35b4cc4b854ece315832588bc182) | `` czkawka: 11.0.1 -> 12.0.0 ``                                                                                                    |
| [`afe08de8`](https://github.com/NixOS/nixpkgs/commit/afe08de82e9b643dc3f53e785a3d205627baf465) | `` rs-lxmf: 1.0.0 -> 1.0.1 ``                                                                                                      |
| [`bee17a8c`](https://github.com/NixOS/nixpkgs/commit/bee17a8c30986ada0d3640875f730106ef900f1f) | `` codebase-memory-mcp: use makeFlags and makefile ``                                                                              |
| [`24eb722b`](https://github.com/NixOS/nixpkgs/commit/24eb722bb344774178c79a21aed4cef0c85c747c) | `` codebase-memory-mcp: add some new lines for clarity ``                                                                          |
| [`d86f222a`](https://github.com/NixOS/nixpkgs/commit/d86f222ad02aad7a6f4811019b48516597ccf70b) | `` lemon-graph: add hzeller as maintainer ``                                                                                       |
| [`4bd105af`](https://github.com/NixOS/nixpkgs/commit/4bd105af4cb255e4bfb3f4b81361db5edc4a2c17) | `` md-tui: 0.10.2 -> 0.10.3 ``                                                                                                     |
| [`80b0785e`](https://github.com/NixOS/nixpkgs/commit/80b0785e2e55f663e057e7b719613687f2ca6acb) | `` pyp: cleanup ``                                                                                                                 |
| [`958d21d0`](https://github.com/NixOS/nixpkgs/commit/958d21d0da32b22292e9512fdf3579fb72f32ece) | `` python3Packages.colcon-ros-domain-id-coordinator: fetch correct tag ``                                                          |
| [`6c34a269`](https://github.com/NixOS/nixpkgs/commit/6c34a26998ffebf408973236fbec1179265c4b9d) | `` cloudflare-dynamic-dns: 4.4.5 -> 4.5.0 ``                                                                                       |
| [`0c81eaad`](https://github.com/NixOS/nixpkgs/commit/0c81eaadca25a8fcfeeb2a0dc46cb9a481d4ebf2) | `` chromium-hsts-preload-list: init at 151.0.7891.2 ``                                                                             |
| [`e4c6a361`](https://github.com/NixOS/nixpkgs/commit/e4c6a36155679081f20ee5495097c924d03b8694) | `` editorconfig-checker: 3.7.0 -> 3.8.0 ``                                                                                         |
| [`eeecf0ad`](https://github.com/NixOS/nixpkgs/commit/eeecf0ad8b635603609e2bdd333d71434177e38f) | `` python3Packages.pyleri: fix hash ``                                                                                             |
| [`696dfc99`](https://github.com/NixOS/nixpkgs/commit/696dfc991b1a980164849bbad98a55acbcba6049) | `` ladybird: 0-unstable-2026-05-04 -> 0-unstable-2026-06-05 ``                                                                     |
| [`947ea00c`](https://github.com/NixOS/nixpkgs/commit/947ea00c4f82f049c8b5762e01d146ec5259117d) | `` fselect: 0.10.1 -> 0.10.2 ``                                                                                                    |
| [`e1a35732`](https://github.com/NixOS/nixpkgs/commit/e1a35732f8e4a987c5e00fa224974526ff896f94) | `` feishu-cli: 1.32.0 -> 1.34.0 ``                                                                                                 |
| [`8f8df992`](https://github.com/NixOS/nixpkgs/commit/8f8df99200697aa99a6b504fe16953b473155926) | `` .github/ISSUE_TEMPLATE: fix hydra icon links ``                                                                                 |
| [`b6d44493`](https://github.com/NixOS/nixpkgs/commit/b6d4449398a92718cfaed03bc0e954b6dd8ab448) | `` bottom: 0.13.0 -> 0.14.2 ``                                                                                                     |
| [`43a579fd`](https://github.com/NixOS/nixpkgs/commit/43a579fdae1f7f0273ec841a15d9f3755420bac0) | `` phpPackages.grumphp: 2.21.0 -> 2.22.0 ``                                                                                        |
| [`4cb2e00f`](https://github.com/NixOS/nixpkgs/commit/4cb2e00fc470dee0cc07ec68a51309c0b6c5c486) | `` nbping: 0.7.0 -> 0.7.1 ``                                                                                                       |
| [`3df64cb5`](https://github.com/NixOS/nixpkgs/commit/3df64cb5d10263cc0b48f0a8d2c726be6cd7f794) | `` rtk: 0.42.4 -> 0.43.0 ``                                                                                                        |
| [`0cb64fad`](https://github.com/NixOS/nixpkgs/commit/0cb64fad203bd8729ab3aabab7d98ffef83c5329) | `` inter: use installFonts ``                                                                                                      |
| [`18db003d`](https://github.com/NixOS/nixpkgs/commit/18db003df1598240a4fc7559df4494d0f122cf98) | `` lstk: 0.13.0 -> 0.14.0 ``                                                                                                       |
| [`ed3910e2`](https://github.com/NixOS/nixpkgs/commit/ed3910e2c692c7c6a4ac2edca3f7a0b5238659b9) | `` teleport_{17,18}: pnpm_10_29_2 -> pnpm_10 ``                                                                                    |
| [`2d410b8a`](https://github.com/NixOS/nixpkgs/commit/2d410b8a1be7e55a10251600ad95e4bb230610cd) | `` postgresqlPackages.pg_roaringbitmap: 1.1.0 -> 1.2.0 ``                                                                          |
| [`3b283631`](https://github.com/NixOS/nixpkgs/commit/3b283631a6dcfba4cc9b358af9bf0b643ced155c) | `` vscode-extensions.waderyan.gitblame: 13.0.1 -> 13.1.0 ``                                                                        |
| [`2296dc84`](https://github.com/NixOS/nixpkgs/commit/2296dc841ee1af8b41ac39400f386962f7a7fb4c) | `` davinci-resolve: 20.3.3 -> 21.0.1 ``                                                                                            |
| [`50fb927b`](https://github.com/NixOS/nixpkgs/commit/50fb927b0d1a9f16fc254627e6f22ba8d5605ba2) | `` voicevox: pnpm_10_29_2 -> pnpm_10 ``                                                                                            |
| [`0ac71b40`](https://github.com/NixOS/nixpkgs/commit/0ac71b409f755bfcada83366b68d0b45feacf981) | `` python3Packages.etils: 1.13.0 -> 1.14.0 ``                                                                                      |
| [`c598b514`](https://github.com/NixOS/nixpkgs/commit/c598b5141216f41bf0958c6a8dbb3186b048a763) | `` glaze: 7.8.2 -> 7.8.3 ``                                                                                                        |
| [`613e641c`](https://github.com/NixOS/nixpkgs/commit/613e641c95d138ab190bbb24efe65868ecd30f46) | `` heroic-unwrapped: pnpm_10_29_2 -> pnpm_10 ``                                                                                    |
| [`49020d0b`](https://github.com/NixOS/nixpkgs/commit/49020d0b685a7bf76adb75354f7c1720b59087fe) | `` python3Packages.lacuscore: 1.24.7 -> 1.25.0 ``                                                                                  |
| [`8c8159cd`](https://github.com/NixOS/nixpkgs/commit/8c8159cdfdaf1a9ef9901e1ac0c97aa630178b78) | `` psleep: init at 0.3.0 ``                                                                                                        |
| [`6450dc0c`](https://github.com/NixOS/nixpkgs/commit/6450dc0c44aa550c17b52bcaff6387907fa44f39) | `` kulala-core: improve description ``                                                                                             |
| [`33882863`](https://github.com/NixOS/nixpkgs/commit/33882863bb7d5f722e946820d3ae8a28e9a5675c) | `` python3Packages.yara-x: 1.18.0 -> 1.19.0 ``                                                                                     |
| [`db155a44`](https://github.com/NixOS/nixpkgs/commit/db155a44a08e5d738877e18d809058c7c8e2c280) | `` Revert "nginx.tests: migrate most to nspawn containers" ``                                                                      |
| [`19bd60de`](https://github.com/NixOS/nixpkgs/commit/19bd60de3646c206ae8872650e0d0edd52555234) | `` mcp-grafana: 0.16.0 -> 0.17.0 ``                                                                                                |
| [`accc739d`](https://github.com/NixOS/nixpkgs/commit/accc739d1ae7134abe5af9047e680016633066f8) | `` nixos/tests/your_spotify: switch test to mongodb-ce ``                                                                          |
| [`67b22583`](https://github.com/NixOS/nixpkgs/commit/67b225831eaca95d0396a3ce8360cc73b7f2b8f6) | `` python3Packages.pysigma-backend-elasticsearch: 2.0.3 -> 2.1.0 ``                                                                |
| [`422a255d`](https://github.com/NixOS/nixpkgs/commit/422a255dd364ff481be7cc4ade5596afbdd088fe) | `` google-chrome: 149.0.7827.196 -> 149.0.7827.200 ``                                                                              |
| [`4fab4212`](https://github.com/NixOS/nixpkgs/commit/4fab42124c1459530d8283138ce5bf94d856d674) | `` python3Packages.oelint-data: 1.5.6 -> 1.5.8 ``                                                                                  |
| [`58136cc6`](https://github.com/NixOS/nixpkgs/commit/58136cc66d2e66288f8b9297727597dd6ca5cc33) | `` gh-aw: 0.79.8 -> 0.80.9 ``                                                                                                      |
| [`3eaf2e97`](https://github.com/NixOS/nixpkgs/commit/3eaf2e97694819158c5ed3d0a0745d0ea436bbae) | `` python3Packages.jax: 0.10.0 -> 0.10.2 ``                                                                                        |
| [`ff88e99a`](https://github.com/NixOS/nixpkgs/commit/ff88e99af9d0fcb2e9ad0dba7fa460d3ac2c5ba1) | `` libretro.melonds: 0-unstable-2026-04-20 -> 0-unstable-2026-06-25 ``                                                             |
| [`d8f7d8ae`](https://github.com/NixOS/nixpkgs/commit/d8f7d8ae696d5932e418b7039098691c4e9bf7e6) | `` python3Packages.aioimmich: 0.15.0 -> 0.15.1 ``                                                                                  |
| [`cffe9b92`](https://github.com/NixOS/nixpkgs/commit/cffe9b926b81b1652fce36122104da631fd5a0a4) | `` tmuxp: 1.70.0 → 1.71.0 ``                                                                                                       |
| [`21ae749c`](https://github.com/NixOS/nixpkgs/commit/21ae749caec2b4e5edeab35fd8d74323f9daecbc) | `` kimai: 2.60.0 -> 2.61.0 ``                                                                                                      |
| [`ab014093`](https://github.com/NixOS/nixpkgs/commit/ab0140932d51702f1074ce6952be07a9412dcb44) | `` tombi: 1.1.5 -> 1.1.6 ``                                                                                                        |
| [`0a5a8529`](https://github.com/NixOS/nixpkgs/commit/0a5a85293d9362dde7d145909f859a5231722640) | `` resterm: 0.42.1 -> 0.44.3 ``                                                                                                    |
| [`e2216136`](https://github.com/NixOS/nixpkgs/commit/e221613658d777b815b71fd323030d138d46b734) | `` opengist: 1.12.2 -> 1.13.1 ``                                                                                                   |
| [`bc237fdc`](https://github.com/NixOS/nixpkgs/commit/bc237fdc0acd50181a8c1d7fff897e2675a0d997) | `` nixos/tests/podman: replace deprecated os.system in tls-ghostunnel ``                                                           |
| [`b21c2e76`](https://github.com/NixOS/nixpkgs/commit/b21c2e764c721226ae94af1f57c5962e9f03a54b) | `` libretro.dolphin: 0-unstable-2026-04-08 -> 0-unstable-2026-06-26 ``                                                             |
| [`ebd782ba`](https://github.com/NixOS/nixpkgs/commit/ebd782baf852fa9223ad5aabd04e9071edd7c9fd) | `` podman: Limit the platform to linux ``                                                                                          |
| [`7aca9bc7`](https://github.com/NixOS/nixpkgs/commit/7aca9bc7b4ae989ea1fc40b9950ac548863656b3) | `` iosevka: 34.4.0 -> 34.7.0 ``                                                                                                    |
| [`4b5f0a16`](https://github.com/NixOS/nixpkgs/commit/4b5f0a166da3bc9143276e7c6caa0cc1964f018b) | `` comaps: 2026.03.23-5 -> 2026.06.05-11 ``                                                                                        |
| [`04eba4c4`](https://github.com/NixOS/nixpkgs/commit/04eba4c46de098df9efa59ebb086fcd4a317f15e) | `` fasmg: l5p0 -> l7xm ``                                                                                                          |
| [`657e8e7d`](https://github.com/NixOS/nixpkgs/commit/657e8e7d051d0bfeb6f5fd8f21eec89d901aa467) | `` terraform-providers.spacelift-io_spacelift: 1.52.0 -> 1.52.2 ``                                                                 |
| [`aa3dbbc6`](https://github.com/NixOS/nixpkgs/commit/aa3dbbc6aa1965780416ca745b2819cf543fb136) | `` solanum: 0-unstable-2026-05-24 -> 0-unstable-2026-06-23 ``                                                                      |
| [`9dade630`](https://github.com/NixOS/nixpkgs/commit/9dade630d90036ccd0d104e6cf5b710a89db6261) | `` linux_xanmod_latest: 7.0.12 -> 7.0.14 ``                                                                                        |
| [`7e844dbe`](https://github.com/NixOS/nixpkgs/commit/7e844dbe0e8e0c716a6e5ba1c898c87da1b1660c) | `` linux_xanmod: 6.18.35 -> 6.18.37 ``                                                                                             |
| [`27b031b4`](https://github.com/NixOS/nixpkgs/commit/27b031b4545774211ad62685d7bb3eff50921e9c) | `` vscode-extensions.betterthantomorrow.calva: 2.0.591 -> 2.0.593 ``                                                               |
| [`dcc4fcf8`](https://github.com/NixOS/nixpkgs/commit/dcc4fcf8aeae1f77d81e63241e0d753c2dffc8cd) | `` openlinkhub: install binary to `$out/opt/OpenLinkHub` ``                                                                        |
| [`b891b22f`](https://github.com/NixOS/nixpkgs/commit/b891b22fd83336b518487ab1ca47f6de73128f12) | `` python3Packages.airos: 0.6.8 -> 0.6.9 ``                                                                                        |
| [`5c769b19`](https://github.com/NixOS/nixpkgs/commit/5c769b1942f87bf26937d8b2ac31c8c254f0cad3) | `` python3Packages.moyopy: 0.12.0 -> 0.13.0 ``                                                                                     |
| [`9f7747b8`](https://github.com/NixOS/nixpkgs/commit/9f7747b8ee02d8d0245e6140097a930cdaf71bdd) | `` box-cli: init at 0.1.112 ``                                                                                                     |
| [`a263c5bc`](https://github.com/NixOS/nixpkgs/commit/a263c5bc1d103e5d34af98eee5a23c85e5eb3e5e) | `` dutctl: 1.0.0-alpha.1-unstable-2026-06-11 -> 1.0.0-alpha.1-unstable-2026-06-25 ``                                               |
| [`ec1dbcbb`](https://github.com/NixOS/nixpkgs/commit/ec1dbcbbd1300dd09b51afb3dc78976a121df88f) | `` pdns: add meta.changelog ``                                                                                                     |
| [`b767296f`](https://github.com/NixOS/nixpkgs/commit/b767296f886cf7a6fe23f913f58bfdd9d18e6e10) | `` nginx.tests: migrate most to nspawn containers ``                                                                               |
| [`881a5eba`](https://github.com/NixOS/nixpkgs/commit/881a5eba9fa859a99ce3af1885adf492fa7b82db) | `` openresty: fix nginx path in resty script ``                                                                                    |
| [`743bfdaf`](https://github.com/NixOS/nixpkgs/commit/743bfdaf106a80368a87bfba56207dd515304b98) | `` pdns-recursor: 5.4.1 -> 5.4.3 ``                                                                                                |
| [`b09918a0`](https://github.com/NixOS/nixpkgs/commit/b09918a07d4587bb36a8e097066b2813120494e7) | `` openresty: wrap restydoc with groff ``                                                                                          |
| [`07645932`](https://github.com/NixOS/nixpkgs/commit/076459328bab4f6d31d09a9d1446ca2d999a13c3) | `` karakeep: pass patches directly to fetchPnpmDeps ``                                                                             |
| [`ad3a0656`](https://github.com/NixOS/nixpkgs/commit/ad3a0656fb8beae4da9985a2de862f49391f5589) | `` openresty: include nginx-variants test in passthru.tests ``                                                                     |
| [`e9f2aca3`](https://github.com/NixOS/nixpkgs/commit/e9f2aca3d1d2bcd255fec2f86fa10e5e93cd1528) | `` openresty: 1.27.1.2 -> 1.31.1.1 ``                                                                                              |
| [`e9f301fc`](https://github.com/NixOS/nixpkgs/commit/e9f301fcf7c34eca2691c6f321b2e6e3a349abe9) | `` nginx: fix test and update script passthru ``                                                                                   |
| [`3b8e905d`](https://github.com/NixOS/nixpkgs/commit/3b8e905df86701a3f64d29b3c82ae5b0384bf703) | `` terraform-mcp-server: 0.5.2 -> 1.0.0 ``                                                                                         |
| [`f15c9270`](https://github.com/NixOS/nixpkgs/commit/f15c92705f8c2702756d6458a41eae4c815d1dcb) | `` linux_zen: 7.0.12 -> 7.1.2 ``                                                                                                   |
| [`0874f3bc`](https://github.com/NixOS/nixpkgs/commit/0874f3bc450dab7a84c656fd2c1c998f18835987) | `` pv: set nixosTests.sanoid as part of passthru.tests ``                                                                          |
| [`22fff727`](https://github.com/NixOS/nixpkgs/commit/22fff7274fe3d3b2c11bd49bfb417265039930df) | `` nixos/syncoid: allow `@timer` syscalls ``                                                                                       |
| [`05f57a7e`](https://github.com/NixOS/nixpkgs/commit/05f57a7e9c40dbb80390b79212232c79f63cc61d) | `` openresty: add update script ``                                                                                                 |
| [`783c1a80`](https://github.com/NixOS/nixpkgs/commit/783c1a807225d2c3c5f5ada6cbb2acef31e37a91) | `` chisel: 1.11.6 -> 1.11.7 ``                                                                                                     |
| [`3741dfbe`](https://github.com/NixOS/nixpkgs/commit/3741dfbe765dfce73c5bb3f980fd3da85b3bccc4) | `` pi-coding-agent: 0.79.8 -> 0.80.2 ``                                                                                            |
| [`a55aec32`](https://github.com/NixOS/nixpkgs/commit/a55aec32e70b408e5e5d357ba0d967b403ba5d3d) | `` brutus: 1.5.1 -> 1.6.0 ``                                                                                                       |
| [`f77ba8a0`](https://github.com/NixOS/nixpkgs/commit/f77ba8a01a98dba28853a87530ef88d368b94341) | `` yafc-ce: add update script passthru attribute ``                                                                                |
| [`89243982`](https://github.com/NixOS/nixpkgs/commit/892439827cd72d4a390a3f341f19c2a0224b83b0) | `` nelm: 1.24.0 -> 1.25.2 ``                                                                                                       |
| [`d77e47f2`](https://github.com/NixOS/nixpkgs/commit/d77e47f230071aa28c0cfd2c6beb5f2b139adeb3) | `` woodpecker-server.webui: build with pnpm v11 ``                                                                                 |
| [`8883d136`](https://github.com/NixOS/nixpkgs/commit/8883d136a241be841056508dc648cbc3bb4eed4b) | `` python3Packages.brother: 6.1.0 -> 6.1.1 ``                                                                                      |
| [`54d67fe2`](https://github.com/NixOS/nixpkgs/commit/54d67fe2555e90ca7cfbbb36dcc125fd16fe5945) | `` freecad: require big-parallel system feature ``                                                                                 |
| [`4b11716e`](https://github.com/NixOS/nixpkgs/commit/4b11716eb799be890928a73343ac0c0ef3faf2fe) | `` python3Packages.niquests: 3.19.1 -> 3.20.0 ``                                                                                   |
| [`c6522861`](https://github.com/NixOS/nixpkgs/commit/c6522861dcf88ba98b71810bbce4797bc8f9bedf) | `` ghqr: 0.4.3 -> 0.5.0 ``                                                                                                         |
| [`ded00ca1`](https://github.com/NixOS/nixpkgs/commit/ded00ca14faa8dcf6e05eec2c700f60eec002c05) | `` kas: 5.3 -> 5.4 ``                                                                                                              |
| [`bf5d1cd8`](https://github.com/NixOS/nixpkgs/commit/bf5d1cd8ffe24c1d3e77dbba9696042fc805f043) | `` slint-lsp: 1.16.1 -> 1.17.0 ``                                                                                                  |
| [`82a46edd`](https://github.com/NixOS/nixpkgs/commit/82a46eddd5d0cd4bffec8705db58efe9df1b1791) | `` supabase-cli: 2.105.0 -> 2.108.0 ``                                                                                             |
| [`426b80cf`](https://github.com/NixOS/nixpkgs/commit/426b80cf3b113e1beda65cd047ca346faf94d7cd) | `` libgedit-gfls: 0.4.1 -> 0.4.2 ``                                                                                                |
| [`906822e2`](https://github.com/NixOS/nixpkgs/commit/906822e24e333e4dac7673711cb3b21add521130) | `` versatiles: 4.2.2 -> 4.5.0 ``                                                                                                   |
| [`9a14c948`](https://github.com/NixOS/nixpkgs/commit/9a14c9489a834e377682e76e8d6cd57acdc34c83) | `` terraform-providers.jianyuan_sentry: 0.15.2 -> 0.15.3 ``                                                                        |
| [`e7131644`](https://github.com/NixOS/nixpkgs/commit/e7131644563844db868bccc9010686a945fcf413) | `` kazumi: 2.1.6 -> 2.1.7 ``                                                                                                       |
| [`999a0646`](https://github.com/NixOS/nixpkgs/commit/999a06462edba653b56fdb9ddaee859c3b3b2beb) | `` google-lighthouse: 13.3.0 -> 13.4.0 ``                                                                                          |
| [`dc6970cb`](https://github.com/NixOS/nixpkgs/commit/dc6970cb15724974f145cc6eaedecf302006cff6) | `` patch2pr: 0.45.0 -> 0.45.1 ``                                                                                                   |
| [`652ecb4d`](https://github.com/NixOS/nixpkgs/commit/652ecb4d6f29c21d100d1289077b2b858f041748) | `` freescout: configure meta.changelog ``                                                                                          |
| [`33bd477c`](https://github.com/NixOS/nixpkgs/commit/33bd477c5dde1e6cb0741cbd1c86be54a199f4fa) | `` freescout: fix passthru tests ``                                                                                                |
| [`530375c0`](https://github.com/NixOS/nixpkgs/commit/530375c0ef1091284c41c75c26c5f302ca105db6) | `` freescout: 1.8.225 -> 1.8.226 ``                                                                                                |
| [`5b383d2b`](https://github.com/NixOS/nixpkgs/commit/5b383d2b43cca06b3cef10931215bbbc1a4b28a1) | `` dolphin-emu-primehack: remove unused pcre dependency ``                                                                         |
| [`6097ea82`](https://github.com/NixOS/nixpkgs/commit/6097ea82e938a4348cd381f730c352fab472be11) | `` terraform-providers.metio_migadu: 2026.6.18 -> 2026.6.25 ``                                                                     |
| [`988f6f8f`](https://github.com/NixOS/nixpkgs/commit/988f6f8f3ba6f45a32a281e23fde173a8ee22309) | `` python3Packages.libtmux: 0.58.1 -> 0.59.0 ``                                                                                    |
| [`0c82b903`](https://github.com/NixOS/nixpkgs/commit/0c82b9032c2e2ff672b3ce1af46e72b998746b4f) | `` tola: init at 0.7.1 ``                                                                                                          |
| [`055a8ac3`](https://github.com/NixOS/nixpkgs/commit/055a8ac31e58e9952e075e6f6b9a1080ce1e1344) | `` ao3downloader: 2026.4.9 -> 2026.6.1 ``                                                                                          |
| [`3055643d`](https://github.com/NixOS/nixpkgs/commit/3055643d37371660018202f8950bdd80addf20fb) | `` terraform-providers.terraform-lxd_lxd: 2.7.1 -> 3.0.1 ``                                                                        |
| [`7e01f1f5`](https://github.com/NixOS/nixpkgs/commit/7e01f1f544793eff4c990bff4f45ad556ed2a9a5) | `` s7: 11.8-unstable-2026-05-22 -> 11.9-unstable-2026-06-27 ``                                                                     |
| [`471a08c6`](https://github.com/NixOS/nixpkgs/commit/471a08c640665fb5ef6129e2676ad926a47f29e4) | `` classads: drop ``                                                                                                               |
| [`2e881c99`](https://github.com/NixOS/nixpkgs/commit/2e881c9990baf9073a4b221491dcdeef61c42ae5) | `` easyeffects: 8.2.4 -> 8.2.5 ``                                                                                                  |
| [`a87153b5`](https://github.com/NixOS/nixpkgs/commit/a87153b56faffa32462f122cee1ec8350a8a68e1) | `` veilid: 0.5.3 -> 0.5.5 ``                                                                                                       |
| [`d613d7c0`](https://github.com/NixOS/nixpkgs/commit/d613d7c02883e3814244736379ae7d8530ee27bb) | `` python3Packages.pythonqwt: 0.16.1 -> 0.16.2 ``                                                                                  |
| [`860fcaec`](https://github.com/NixOS/nixpkgs/commit/860fcaec942fac18b299dabcda5dfa443ba83578) | `` woodpecker-{agent,cli,server}: 3.15.0 -> 3.16.0 ``                                                                              |
| [`0c51b514`](https://github.com/NixOS/nixpkgs/commit/0c51b51468b75a71da4b70ccfb0428822493485d) | `` uv: 0.11.22 -> 0.11.25 ``                                                                                                       |
| [`29bf246d`](https://github.com/NixOS/nixpkgs/commit/29bf246dd82ba1b7107b3c2ca893efb8e147ccf0) | `` vicinae: 0.21.7 -> 0.22.0 ``                                                                                                    |
| [`d7a36877`](https://github.com/NixOS/nixpkgs/commit/d7a368779abec248368e8c0129854b168ed1e68d) | `` podman: 5.8.3 -> 5.8.4 ``                                                                                                       |
| [`e774dd9a`](https://github.com/NixOS/nixpkgs/commit/e774dd9ac0b41959856f03343260324be1a2cad1) | `` nixos/outline: fix crash from quoted DATABASE_URL default ``                                                                    |
| [`9c8be0b5`](https://github.com/NixOS/nixpkgs/commit/9c8be0b5a57ee4d6efe759b05c5c7d7074eac65c) | `` nixos/tests/outline: Switch from VM to container ``                                                                             |
| [`069e805a`](https://github.com/NixOS/nixpkgs/commit/069e805a77ebb91e02a4e371dd0671e297a30f3a) | `` _7zip-zstd-rar: 26.01-v1.5.7-R1 -> 26.02-v1.5.7-R1 ``                                                                           |
| [`6f8d42ec`](https://github.com/NixOS/nixpkgs/commit/6f8d42ecf21a6fe165ef3be9a49b7b946be1d0ed) | `` dbcsr: 2.9.1 -> 2.10.0 ``                                                                                                       |
| [`4455b767`](https://github.com/NixOS/nixpkgs/commit/4455b767142c8a1bb27d54ff9d7c529290969fbd) | `` aws-sso-cli: 2.2.4 -> 2.3.1 ``                                                                                                  |
| [`63244690`](https://github.com/NixOS/nixpkgs/commit/632446907f51e9376e71ac5b4a74f541bb9d1c98) | `` nextcloud-client: 33.0.5 -> 33.0.6 ``                                                                                           |
| [`9d04b9cc`](https://github.com/NixOS/nixpkgs/commit/9d04b9cc960309bf64ef05744ff26b4823b26a85) | `` home-assistant-custom-components.blueprints-updater: 2.8.1 -> 2.9.0 ``                                                          |
| [`0ebab547`](https://github.com/NixOS/nixpkgs/commit/0ebab547359ce540a586b81184e57fc4ff79e223) | `` tokscale: 2.0.26 -> 4.0.4 ``                                                                                                    |
| [`a47702c9`](https://github.com/NixOS/nixpkgs/commit/a47702c9dfe87c27e5db1342fcea846a635dcd20) | `` doc/neovim: fix formatting ``                                                                                                   |
| [`6474a24f`](https://github.com/NixOS/nixpkgs/commit/6474a24fddf9544a3210720dd8bb20a8571d1a29) | `` neovim/tests: use override instead of overrideAttrs for wrapper options ``                                                      |
| [`f7b9e910`](https://github.com/NixOS/nixpkgs/commit/f7b9e91062a7e3bdab65f4dbb0e7e6c81636b388) | `` doc/neovim: document plugin lua config type option ``                                                                           |
| [`9742b211`](https://github.com/NixOS/nixpkgs/commit/9742b211f4a53a79cbcb03033d884d82dcd0f034) | `` doc/neovim: fix VimScript comments in examples ``                                                                               |
| [`46689fa7`](https://github.com/NixOS/nixpkgs/commit/46689fa74ac215e6b307a18016566c3165ecc339) | `` doc/neovim: correct configuration overrides example ``                                                                          |
| [`66e23f41`](https://github.com/NixOS/nixpkgs/commit/66e23f410b07195caa4bb05b5cab80826b763ce6) | `` doc/neovim: document wrapNeovimUnstable options ``                                                                              |
| [`23507e17`](https://github.com/NixOS/nixpkgs/commit/23507e17e7f2edd691dfcc70e1d4b0b410c4e1ee) | `` ci/owners: add NixOS/neovim for neovim doc ``                                                                                   |
| [`2f3e4c10`](https://github.com/NixOS/nixpkgs/commit/2f3e4c1013a58cdf3fc2afc3e5bd720e75e27d77) | `` home-assistant-custom-lovelace-modules.custom-brand-icons: 2026.06.3 -> 2026.06.4 ``                                            |
| [`7ed292fb`](https://github.com/NixOS/nixpkgs/commit/7ed292fb378e0098c2eb34755034b243c15e7e6f) | `` postgresqlPackages.pg_safeupdate: 1.5 -> 1.6 ``                                                                                 |
| [`b2b419d0`](https://github.com/NixOS/nixpkgs/commit/b2b419d092c73ac676b66532ade58ccb2196d8b9) | `` dwproton-bin: dwproton-11.0-3 -> dwproton-11.0-5 ``                                                                             |
| [`9b49cc5c`](https://github.com/NixOS/nixpkgs/commit/9b49cc5ca0596879020dd7ac664c9aaf08df480d) | `` postgresql18Packages.pgaudit: init at 18.0 ``                                                                                   |
| [`a4ecf307`](https://github.com/NixOS/nixpkgs/commit/a4ecf307158d9c3d1da7201689d873286cb28a74) | `` postgresqlPackages.{age,pg_hint_plan,pg_safeupdate,pgaudit}: remove obsolete package versions for PG 13 ``                      |
| [`aee003a2`](https://github.com/NixOS/nixpkgs/commit/aee003a252c6e601564d75106597043166dcd3bb) | `` music-assistant-desktop: 0.4.0 -> 0.4.2 ``                                                                                      |
| [`a0389e0e`](https://github.com/NixOS/nixpkgs/commit/a0389e0e8c113d79e94954dbe9b682a9913c518b) | `` ktailctl: 0.21.5 -> 0.22.0 ``                                                                                                   |
| [`e9734740`](https://github.com/NixOS/nixpkgs/commit/e9734740531f2133ce1074a7ab1cabb648a9be4e) | `` home-assistant-custom-components.powercalc: 1.21.0 -> 1.21.2 ``                                                                 |
| [`c14a0824`](https://github.com/NixOS/nixpkgs/commit/c14a0824b882bfa0167be2b8994ca20e2ff2efb5) | `` mirrord: 3.219.0 -> 3.223.0 ``                                                                                                  |
| [`d384512e`](https://github.com/NixOS/nixpkgs/commit/d384512ee80dbd84755962da3cb02105d8225ef3) | `` nixos/tabbyapi: add writable HOME and cache ``                                                                                  |
| [`4f355aab`](https://github.com/NixOS/nixpkgs/commit/4f355aab667a98e701a85716abbebbf27f813260) | `` matcha: 0.40.1 -> 0.43.0 ``                                                                                                     |
| [`9302bd55`](https://github.com/NixOS/nixpkgs/commit/9302bd5507628bc5acf8dd96d71532b84245717c) | `` sdl_gamecontrollerdb: 0-unstable-2026-06-12 -> 0-unstable-2026-06-26 ``                                                         |
| [`8a9e86a4`](https://github.com/NixOS/nixpkgs/commit/8a9e86a4b634e8b5ee7f26d5faeaff681476767e) | `` dependabot-cli: 1.89.0 -> 1.90.0 ``                                                                                             |
| [`cbe7fae9`](https://github.com/NixOS/nixpkgs/commit/cbe7fae921768104faf748a8e44f74c004a1b6e5) | `` rocqPackages.rocqnavi: init at 0.5.0 ``                                                                                         |
| [`13438077`](https://github.com/NixOS/nixpkgs/commit/13438077eea71c0672dee709ad62dc8eb753ad54) | `` v2ray-domain-list-community: 20260618031303 -> 20260627053650 ``                                                                |
| [`a05d7f9e`](https://github.com/NixOS/nixpkgs/commit/a05d7f9e123495a8394c30b3ea96ffc7c82fba41) | `` tabbyapi: unstable-2026-06-13 -> unstable-2026-06-27 ``                                                                         |
| [`57dd769a`](https://github.com/NixOS/nixpkgs/commit/57dd769ad77916286f60299308b583f1297cb633) | `` copilot-language-server: 1.509.0 -> 1.513.0 ``                                                                                  |
| [`1501c08a`](https://github.com/NixOS/nixpkgs/commit/1501c08af3cc131e2eb77439584b73f3a4ba7b1d) | `` nixos/kubo: fix typo in fuseAllowOther setting ``                                                                               |
| [`8d8350a7`](https://github.com/NixOS/nixpkgs/commit/8d8350a77bfeef2d6915648c438ffd96a7bc6aa5) | `` protoc-gen-grpc-java: 1.81.0 -> 1.82.1 ``                                                                                       |
| [`77ea4e37`](https://github.com/NixOS/nixpkgs/commit/77ea4e37f84a559c32e38391066198989e9f1b32) | `` linux_6_18: 6.18.36 -> 6.18.37 ``                                                                                               |
| [`ae05d822`](https://github.com/NixOS/nixpkgs/commit/ae05d822afa333fd35d417b399beb1da0ebb689d) | `` linux_7_0: 7.0.13 -> 7.0.14 ``                                                                                                  |
| [`0899fedf`](https://github.com/NixOS/nixpkgs/commit/0899fedf44910c9dd259a937e744a69a3e96d874) | `` linux_7_1: 7.1.1 -> 7.1.2 ``                                                                                                    |
| [`4dc1b041`](https://github.com/NixOS/nixpkgs/commit/4dc1b0419428e13eb04856b65c4cda198d788d3a) | `` telemt: 3.4.18 -> 3.4.19 ``                                                                                                     |
| [`42308f57`](https://github.com/NixOS/nixpkgs/commit/42308f570774f0f3fe9e2def1e6bc483c287ef02) | `` shaperglot-cli: 1.2.0 -> 1.2.1 ``                                                                                               |
| [`f5621e45`](https://github.com/NixOS/nixpkgs/commit/f5621e45121ad4900619b0959a5368e6ce72dbf4) | `` incus-ui-canonical: 0.21.0 -> 0.21.2 ``                                                                                         |
| [`d93350e0`](https://github.com/NixOS/nixpkgs/commit/d93350e0c21f22d4b0f97277714202f098326fd2) | `` pnpm_10: 10.34.0 -> 10.34.4 ``                                                                                                  |
| [`893ae213`](https://github.com/NixOS/nixpkgs/commit/893ae213cabc75762bfd953c0ecf67c0e1368340) | `` treewide: pin pnpm_10 packages with missing integrity fields to pnpm_10_34_0 ``                                                 |
| [`45933c06`](https://github.com/NixOS/nixpkgs/commit/45933c060a1ca896c751f15723dd3a5d9e015d67) | `` libretro.opera: 0-unstable-2026-06-15 -> 0-unstable-2026-06-19 ``                                                               |
| [`c2942d7b`](https://github.com/NixOS/nixpkgs/commit/c2942d7b0ef20888b2adaafcf8b4c79358c245bf) | `` python3Packages.pyatv: 0.17.0 -> 0.18.0 ``                                                                                      |
| [`e1d34cf7`](https://github.com/NixOS/nixpkgs/commit/e1d34cf7add373c352be43147f8e759d13fde764) | `` pnpm_10_34_0: init ``                                                                                                           |
| [`f74dae84`](https://github.com/NixOS/nixpkgs/commit/f74dae849727a177dafb8686c1d573b945ff69ff) | `` perlPackages.BytesRandomSecure: add patch for CVE-2026-11625 ``                                                                 |
| [`78581b87`](https://github.com/NixOS/nixpkgs/commit/78581b87cd0b96d2cd1a36aa5d20aad57b9a1d4e) | `` perlPackages.BytesRandomSecureTiny: add patch for CVE-2026-11702 ``                                                             |
| [`d1c6c4f6`](https://github.com/NixOS/nixpkgs/commit/d1c6c4f6eab656f47b4db44d06ae73e49f1a108a) | `` mongodb-ce: add `__structuredAttrs`, `strictDeps` ``                                                                            |
| [`651f3b12`](https://github.com/NixOS/nixpkgs/commit/651f3b12fd44a5c920a5d91bb8bff12c79fe7598) | `` mongodb-ce: unbreak on darwin ``                                                                                                |
| [`a530361e`](https://github.com/NixOS/nixpkgs/commit/a530361ef2b70186ea6dec789790ac57de1f58f4) | `` blesh: patch build helper shebangs ``                                                                                           |
| [`c85eb5f9`](https://github.com/NixOS/nixpkgs/commit/c85eb5f9faaec8dfba051b1facb8e77bb472b737) | `` blesh: 0.4.0-devel3-unstable-2026-06-21 -> 0.4.0-devel3-unstable-2026-06-27 ``                                                  |
| [`bf4f3d5c`](https://github.com/NixOS/nixpkgs/commit/bf4f3d5c857c1826ab4869da5312d50ce38ca14f) | `` reticulum-group-chat: init at 1.11.0 ``                                                                                         |
| [`c6202049`](https://github.com/NixOS/nixpkgs/commit/c6202049fb490b29fa21b7528cf8ab2cab75502a) | `` waydroid-helper: add missing dependency ``                                                                                      |
| [`bdd24ff7`](https://github.com/NixOS/nixpkgs/commit/bdd24ff79f66ef8c8a695799982779fdccb36c7d) | `` python3Packages.microsoft-kiota-serialization-text: 1.10.3 -> 1.11.6 ``                                                         |
| [`764bdaec`](https://github.com/NixOS/nixpkgs/commit/764bdaec8dd1978bb68f16819ae236c4596798f1) | `` python3Packages.microsoft-kiota-serialization-multipart: 1.10.3 -> 1.11.6 ``                                                    |
| [`9a289861`](https://github.com/NixOS/nixpkgs/commit/9a289861be27be2c9bd206a0441475c67a673266) | `` python3Packages.microsoft-kiota-serialization-json: 1.10.3 -> 1.11.6 ``                                                         |
| [`5eac6bee`](https://github.com/NixOS/nixpkgs/commit/5eac6bee3fcb35cd942684557771b8091a391bb8) | `` python3Packages.microsoft-kiota-http: 1.10.3 -> 1.11.6 ``                                                                       |
| [`3cedbfd2`](https://github.com/NixOS/nixpkgs/commit/3cedbfd22c44d9c100e4fe8a33a490886d81e1c9) | `` python3Packages.microsoft-kiota-authentication-azure: 1.10.3 -> 1.11.6 ``                                                       |
| [`f58d28f7`](https://github.com/NixOS/nixpkgs/commit/f58d28f73fcf63fc23c9e1b52b6f301f6809ec63) | `` python3Packages.microsoft-kiota-abstractions: 1.10.3 -> 1.11.6 ``                                                               |
| [`acf28333`](https://github.com/NixOS/nixpkgs/commit/acf28333f7c4155aacbf9df7c88cdc4b32b8691d) | `` python3Packages.govee-ble: 1.2.0 -> 1.4.0 ``                                                                                    |
| [`68e4176e`](https://github.com/NixOS/nixpkgs/commit/68e4176ee6d959a076ac8af8e2c2d75b3acc8880) | `` python3Packages.google-cloud-vpc-access: 1.16.0 -> 1.17.0 ``                                                                    |
| [`e86ee0c8`](https://github.com/NixOS/nixpkgs/commit/e86ee0c868e515e3acadb806ed17aec6a526a89f) | `` qui: 1.20.0 -> 1.21.0 ``                                                                                                        |
| [`54a72d01`](https://github.com/NixOS/nixpkgs/commit/54a72d01670a85d287d8442538de2deac4169966) | `` python3Packages.google-cloud-workflows: 1.22.0 -> 1.23.0 ``                                                                     |
| [`4f9bbfc5`](https://github.com/NixOS/nixpkgs/commit/4f9bbfc5a8f392c4231ec5d5522b0c1a74d6a35d) | `` python3Packages.google-cloud-webrisk: 1.21.0 -> 1.22.0 ``                                                                       |
| [`dd827182`](https://github.com/NixOS/nixpkgs/commit/dd82718270994cdb9b57401cb2a07022a7723308) | `` python3Packages.pybase62: 0.5.0 -> 1.0.0 ``                                                                                     |
| [`cda2ff95`](https://github.com/NixOS/nixpkgs/commit/cda2ff95ecc3b5bfda1f0eef4cf5c6337d58bb5f) | `` terraform-providers.cloudflare_cloudflare: 5.20.0 -> 5.21.1 ``                                                                  |
| [`87163569`](https://github.com/NixOS/nixpkgs/commit/871635694326d93bc4328d6511db936f89f34dd0) | `` dbeaver-bin: 26.1.0 -> 26.1.1 ``                                                                                                |
| [`9db30afa`](https://github.com/NixOS/nixpkgs/commit/9db30afab530488312db89e648687299103dcdb8) | `` pgrok: update to pnpm 11 ``                                                                                                     |
| [`f727724f`](https://github.com/NixOS/nixpkgs/commit/f727724f2c81d46b13f9f02fc79bf344ed6c2d25) | `` windsurf: rename to devin-desktop, bump to 3.3.18 ``                                                                            |
| [`79a8e945`](https://github.com/NixOS/nixpkgs/commit/79a8e945864be8980ab4cbd9e11c77dee09d91b7) | `` igir: 5.1.0 -> 5.2.1 ``                                                                                                         |
| [`6d8c9047`](https://github.com/NixOS/nixpkgs/commit/6d8c9047d3a34145cb5dc84e8e909797103aac4b) | `` attic-client: 0-unstable-2026-06-14 -> 0-unstable-2026-06-26 ``                                                                 |
| [`d31c61f7`](https://github.com/NixOS/nixpkgs/commit/d31c61f700b1a65b8e374f9d57de091228831c82) | `` python3Packages.python-smarttub: migrate to finalAttrs ``                                                                       |
| [`af3fbfd8`](https://github.com/NixOS/nixpkgs/commit/af3fbfd8f39eae8303ee44e0871cd5a16cbe732e) | `` python3Packages.iamdata: 0.1.202606261 -> 0.1.202606271 ``                                                                      |
| [`71101bbb`](https://github.com/NixOS/nixpkgs/commit/71101bbb822041df2f053eeabb9e2d5b76f834f7) | `` dioxus-cli: upgrade wasm bindgen to 126 ``                                                                                      |
| [`abd60816`](https://github.com/NixOS/nixpkgs/commit/abd6081647d0c35ab434647b35185b980169a9a5) | `` wasm-bindgen-cli_0_2_126: init ``                                                                                               |
| [`962c07a0`](https://github.com/NixOS/nixpkgs/commit/962c07a057e65cb058781deb24397af1acd7db6a) | `` manifold: 3.5.1 -> 3.5.2 ``                                                                                                     |
| [`062e157d`](https://github.com/NixOS/nixpkgs/commit/062e157d63fa4596ef866ac6b34c4958d5de849c) | `` textlint: 15.2.1 -> 15.7.1 ``                                                                                                   |
| [`6ba6b67a`](https://github.com/NixOS/nixpkgs/commit/6ba6b67a9c491b82ab4d9468e36840b9163270d3) | `` python3Packages.python-smarttub: 0.0.47 -> 0.0.48 ``                                                                            |
| [`ed033eb3`](https://github.com/NixOS/nixpkgs/commit/ed033eb3a2fef68087c5208ad2fd7a3e89e3d712) | `` oh-my-posh: 29.18.0 -> 29.19.0 ``                                                                                               |
| [`dc50dcfd`](https://github.com/NixOS/nixpkgs/commit/dc50dcfdead7beb457498c99b35a35374fedfc20) | `` lemmy-ui: use pnpm_11 ``                                                                                                        |
| [`fd30c265`](https://github.com/NixOS/nixpkgs/commit/fd30c265e510dd61da43b4695a22a02f5f94d207) | `` kicad-unstable{,-small}: 2026-05-08 -> 2026-06-27 ``                                                                            |
| [`6b379ca6`](https://github.com/NixOS/nixpkgs/commit/6b379ca683a4696bc3a283e67758e5db181add3f) | `` pear-desktop: unpinn pnpm to stop depending on marked insecure package and bring it back to cache ``                            |
| [`bf959d33`](https://github.com/NixOS/nixpkgs/commit/bf959d33312809ad956ff73309dc78d82fcfc160) | `` python3Packages.afdko: fix build on darwin ``                                                                                   |
| [`a2bb7f10`](https://github.com/NixOS/nixpkgs/commit/a2bb7f10685284679519c9d991bcdb0b1e8ec787) | `` luaPackages.telescope-nvim: scm-1-9377230aa5305d9e9aca4ed8dadf1070fb4aa9fc -> scm-1-427b576c16792edad01a92b89721d923c19ad60f `` |
| [`3efe3c35`](https://github.com/NixOS/nixpkgs/commit/3efe3c35b5ae432bca177e26554dc3f2ee210b4c) | `` luaPackages.teal-language-server: 0.1.3-1 -> 0.1.4-1 ``                                                                         |
| [`b92a3029`](https://github.com/NixOS/nixpkgs/commit/b92a3029b56c947ce909c5fb51a62796855567a7) | `` luaPackages.mini-test: 0.17.0-1 -> 0.18.0-1 ``                                                                                  |
| [`a19e6f82`](https://github.com/NixOS/nixpkgs/commit/a19e6f82cca0e1750c412b9f7655664a600d7a26) | `` luaPackages.kulala-nvim: 6.15.3-1 -> 6.17.0-1 ``                                                                                |
| [`d7cc6de0`](https://github.com/NixOS/nixpkgs/commit/d7cc6de0c6c40621575b194d6bb325d9fcf9f51b) | `` luaPackages.grug-far-nvim: 1.6.71-1 -> 1.6.72-1 ``                                                                              |

*... and 3441 more commits (truncated)*